### PR TITLE
Add ADTLERT as an optional ERT backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,25 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+  adtlert:
+    name: "ADTLERT backend (ubuntu, py3.11, CPU)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install CPU backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e . pytest
+          python -m pip install "adtlert>=0.1,<0.2" "pygimli>=1.5.5,<2.0"
+
+      - name: Run ADTLERT integration tests
+        run: pytest -q tests/test_ert_adtlert_backend.py tests/test_ert_mesh_import.py

--- a/PyHydroGeophysX/inversion/_time_lapse_workflow.py
+++ b/PyHydroGeophysX/inversion/_time_lapse_workflow.py
@@ -30,6 +30,7 @@ DEFAULT_TL = {
     "max_iterations": 15, "relativeError": 0.05, "absoluteUError": 0.0,
     "method": "cgls", "mesh_quality": 34.0, "rho_min": 1.0, "rho_max": 1.0e4,
     "windowed": False, "window_size": 3, "save_memory": False, "instrument": None,
+    "engine": "pyhydro",
     # Lambda relaxation. A trial here is a full joint inversion over every time
     # step, so the default budget is smaller than the single-inversion search.
     "auto_lambda": False, "target_chi2": 1.0, "chi2_tolerance": 0.2,
@@ -156,7 +157,7 @@ def build_timelapse_config(data_files: Sequence[str], measurement_times: Sequenc
         "inversion": {k: p[k] for k in (
             "lambda_val", "alpha", "inversion_type", "max_iterations",
             "relativeError", "method", "mesh_quality", "rho_min", "rho_max",
-            "windowed", "window_size", "save_memory")},
+            "windowed", "window_size", "save_memory", "engine")},
     }
 
 
@@ -190,6 +191,19 @@ def run_timelapse_ert(
     if len(source_files) < 2:
         raise ValueError("Time-lapse inversion needs at least two ERT data files.")
     p = {**DEFAULT_TL, **(params or {})}
+    engine = str(p.get("engine", "pyhydro")).lower()
+    use_windowed = (
+        bool(p.get("windowed", False))
+        and 2 <= int(p["window_size"]) <= len(source_files)
+    )
+    if engine == "adtlert" and not use_windowed:
+        raise ValueError(
+            "engine='adtlert' currently requires windowed=True for time-lapse ERT"
+        )
+    if engine not in ("pyhydro", "adtlert"):
+        raise ValueError(
+            "Time-lapse ERT engine must be 'pyhydro' or windowed 'adtlert'"
+        )
 
     # Derive measurement times + display labels. Filenames that embed dates (e.g.
     # the E4D monthly series 2021-10-08_1400.ohm) give elapsed-day times and date
@@ -219,7 +233,8 @@ def run_timelapse_ert(
     # auto-enable sparse once the dense Gauss-Newton matrices would get large.
     save_memory = bool(p.get("save_memory", False))
     n_unknowns = int(mesh.cellCount()) * len(files)
-    if "save_memory" not in (params or {}) and not save_memory and n_unknowns > _AUTO_SPARSE_UNKNOWNS:
+    if (engine == "pyhydro" and "save_memory" not in (params or {})
+            and not save_memory and n_unknowns > _AUTO_SPARSE_UNKNOWNS):
         save_memory = True
         log(f"Auto-enabling low-memory (sparse) mode: ~{n_unknowns} model unknowns "
             f"({mesh.cellCount()} cells x {len(files)} steps).")
@@ -232,16 +247,16 @@ def run_timelapse_ert(
         model_constraints=(float(p["rho_min"]), float(p["rho_max"])),
         save_memory=save_memory,
     )
-    use_windowed = bool(p.get("windowed", False)) and 2 <= int(p["window_size"]) <= len(files)
     lambda_report: Dict[str, Any] = {"enabled": False}
 
     if use_windowed:
         window_size = int(p["window_size"])
-        log(f"Running windowed {p['inversion_type']} time-lapse inversion: {len(files)} steps, "
+        log(f"Running {engine} windowed {p['inversion_type']} time-lapse "
+            f"inversion: {len(files)} steps, "
             f"window={window_size}, lambda={p['lambda_val']}, alpha={p['alpha']}")
         inversion = WindowedTimeLapseERTInversion(
             data_dir=clean_dir, ert_files=basenames, measurement_times=times,
-            window_size=window_size, mesh=mesh, **inv_kwargs)
+            window_size=window_size, mesh=mesh, engine=engine, **inv_kwargs)
         result = inversion.run(window_parallel=False)
         mode = "windowed"
     else:
@@ -370,6 +385,9 @@ def run_timelapse_ert(
         "status": "ok",
         "direction": "ert_time_lapse_inversion",
         "mode": mode,
+        "engine": engine,
+        "backend_version": str(result.meta.get("backend_version", "")),
+        "linearized_solver": str(result.meta.get("linearized_solver", "")),
         "n_times": int(n_time),
         "mesh_cells": int(res_mesh.cellCount()),
         "inversion_type": str(p["inversion_type"]),

--- a/PyHydroGeophysX/inversion/ert_inversion.py
+++ b/PyHydroGeophysX/inversion/ert_inversion.py
@@ -4,7 +4,7 @@ Single-time ERT inversion functionality.
 from dataclasses import dataclass, field
 from pathlib import Path
 import sys
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pygimli as pg
@@ -551,6 +551,91 @@ class _PygimliEngine:
         )
 
 
+_ADTLERT_SOLVERS: Dict[str, str] = {
+    "cgls": "pyhydro_cgls",
+    "pyhydro_cgls": "pyhydro_cgls",
+    "lsqr": "lsqr",
+    "normal_cg": "normal_cg",
+    "gpu_cgls": "gpu_cgls",
+}
+
+
+def _adtlert_solver_name(method: str, *, prefer_gpu: bool = False) -> str:
+    if prefer_gpu and str(method).lower() == "cgls":
+        try:
+            import cupy as cp
+
+            if int(cp.cuda.runtime.getDeviceCount()) > 0:
+                return "gpu_cgls"
+        except Exception:  # noqa: BLE001 - CPU fallback is intentional
+            pass
+    solver = _ADTLERT_SOLVERS.get(str(method).lower())
+    if solver is None:
+        choices = ", ".join(sorted(_ADTLERT_SOLVERS))
+        raise ValueError(
+            f"Unknown ADTLERT linearized solver {method!r}; "
+            f"choose one of {choices}."
+        )
+    return solver
+
+
+def _build_adtlert_forward(container, mesh, *, log=_noop_log):
+    """Build one shared ADTLERT forward context for single or windowed ERT."""
+    try:
+        import adtlert
+        from adtlert.forward import mesh_to_adtlert, survey_to_adtlert
+        from adtlert.inversion import ParameterizedERTForward2p5D
+    except ImportError as exc:
+        raise BackendUnavailable(
+            "The ADTLERT ERT backend is unavailable. Install it with "
+            "`pip install \"pyhydrogeophysx[adtlert]\"`."
+        ) from exc
+
+    if int(mesh.dim()) != 2:
+        raise ValueError(
+            "engine='adtlert' currently supports 2D profile meshes only; "
+            "use engine='pygimli' for this mesh"
+        )
+
+    active_ids = np.asarray(
+        [
+            int(cell.id())
+            for cell in mesh.cells()
+            if int(cell.marker()) > 1
+        ],
+        dtype=np.int32,
+    )
+    if active_ids.size == 0:
+        raise ValueError(
+            "the ADTLERT parameter domain has no cells with marker > 1"
+        )
+
+    # createMeshByCellIdx preserves the full-mesh order used by active_ids.
+    # That same order is used for ADTLERT models and the existing result viewers.
+    result_mesh = mesh.createMeshByCellIdx(pg.IVector(active_ids.tolist()))
+    forward_mesh = mesh_to_adtlert(mesh)
+    parameter_mesh = mesh_to_adtlert(result_mesh)
+    survey = survey_to_adtlert(container, dimension=2)
+    geometric_mode = (
+        "analytic" if bool(forward_mesh.is_flat_surface) else "numerical"
+    )
+    forward = ParameterizedERTForward2p5D.from_mesh_survey(
+        forward_mesh,
+        survey,
+        active_ids,
+        regularization_mesh=parameter_mesh,
+        background_mode="pygimli_prolongation",
+        topographic_geometric_factor_mode=geometric_mode,
+        linear_solver_backend="auto",
+    )
+    version = str(getattr(adtlert, "__version__", ""))
+    log(
+        f"  ADTLERT {version or '(unknown version)'}: "
+        f"{mesh.cellCount()} forward cells, {active_ids.size} parameters"
+    )
+    return forward, result_mesh, active_ids, version
+
+
 class _ADTLertEngine:
     """ADTLERT's differentiable 2.5D inversion behind the common ERT contract.
 
@@ -560,66 +645,13 @@ class _ADTLertEngine:
     """
 
     name = "adtlert"
-    _SOLVERS: ClassVar[Dict[str, str]] = {
-        "cgls": "pyhydro_cgls",
-        "pyhydro_cgls": "pyhydro_cgls",
-        "lsqr": "lsqr",
-        "normal_cg": "normal_cg",
-        "gpu_cgls": "gpu_cgls",
-    }
 
     def __init__(self, container, mesh, *, model_constraints=(1e-2, 1e5),
                  method="cgls", log=_noop_log):
-        try:
-            import adtlert
-            from adtlert.forward import mesh_to_adtlert, survey_to_adtlert
-            from adtlert.inversion import ParameterizedERTForward2p5D
-        except ImportError as exc:
-            raise BackendUnavailable(
-                "The ADTLERT ERT backend is unavailable. Install it with "
-                "`pip install \"pyhydrogeophysx[adtlert]\"`."
-            ) from exc
-
-        if int(mesh.dim()) != 2:
-            raise ValueError(
-                "engine='adtlert' currently supports 2D profile meshes only; "
-                "use engine='pygimli' for this mesh"
-            )
-
-        active_ids = np.asarray(
-            [
-                int(cell.id())
-                for cell in mesh.cells()
-                if int(cell.marker()) > 1
-            ],
-            dtype=np.int32,
-        )
-        if active_ids.size == 0:
-            raise ValueError(
-                "the ADTLERT parameter domain has no cells with marker > 1"
-            )
-
-        # createMeshByCellIdx preserves the full-mesh order used by active_ids.
-        # That same order is used for the ADTLERT model and the manager-shaped
-        # result consumed by the existing VTK and Qt paths.
-        self.mesh = mesh.createMeshByCellIdx(pg.IVector(active_ids.tolist()))
-        forward_mesh = mesh_to_adtlert(mesh)
-        parameter_mesh = mesh_to_adtlert(self.mesh)
-        survey = survey_to_adtlert(container, dimension=2)
-        geometric_mode = (
-            "analytic" if bool(forward_mesh.is_flat_surface) else "numerical"
-        )
-        self._forward = ParameterizedERTForward2p5D.from_mesh_survey(
-            forward_mesh,
-            survey,
-            active_ids,
-            regularization_mesh=parameter_mesh,
-            background_mode="pygimli_prolongation",
-            topographic_geometric_factor_mode=geometric_mode,
-            linear_solver_backend="auto",
+        self._forward, self.mesh, active_ids, self._adtlert_version = (
+            _build_adtlert_forward(container, mesh, log=log)
         )
         self.container = container
-        self._adtlert_version = str(getattr(adtlert, "__version__", ""))
         self._observed = np.asarray(container["rhoa"], dtype=float)
         self._errors = np.log1p(np.asarray(container["err"], dtype=float))
         self._initial_model = np.full(
@@ -628,18 +660,7 @@ class _ADTLertEngine:
         self._model_constraints = tuple(
             float(value) for value in model_constraints
         )
-        solver = self._SOLVERS.get(str(method).lower())
-        if solver is None:
-            choices = ", ".join(sorted(self._SOLVERS))
-            raise ValueError(
-                f"Unknown ADTLERT linearized solver {method!r}; "
-                f"choose one of {choices}."
-            )
-        self._solver = solver
-        log(
-            f"  ADTLERT {self._adtlert_version or '(unknown version)'}: "
-            f"{mesh.cellCount()} forward cells, {active_ids.size} parameters"
-        )
+        self._solver = _adtlert_solver_name(method)
 
     def reference_model(self):
         return self._initial_model.copy()

--- a/PyHydroGeophysX/inversion/ert_inversion.py
+++ b/PyHydroGeophysX/inversion/ert_inversion.py
@@ -4,7 +4,7 @@ Single-time ERT inversion functionality.
 from dataclasses import dataclass, field
 from pathlib import Path
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pygimli as pg
@@ -12,6 +12,7 @@ from pygimli.physics import ert
 from scipy.sparse import diags
 
 from PyHydroGeophysX._internal.utils import noop as _noop_log
+from PyHydroGeophysX._internal.optional_dependencies import BackendUnavailable
 from ..forward.ert_forward import ertforandjac2, ertforward2
 from ..solvers.linear_solvers import generalized_solver
 from .base import InversionBase, InversionResult
@@ -550,13 +551,171 @@ class _PygimliEngine:
         )
 
 
-ENGINES = {"pyhydro": _PyHydroEngine, "pygimli": _PygimliEngine}
+class _ADTLertEngine:
+    """ADTLERT's differentiable 2.5D inversion behind the common ERT contract.
+
+    PyGIMLi remains responsible for file loading, QC and mesh generation.  The
+    numerical solve is delegated to ADTLERT, with the parameter-domain cell
+    ordering preserved so the existing viewers and exporters keep working.
+    """
+
+    name = "adtlert"
+    _SOLVERS: ClassVar[Dict[str, str]] = {
+        "cgls": "pyhydro_cgls",
+        "pyhydro_cgls": "pyhydro_cgls",
+        "lsqr": "lsqr",
+        "normal_cg": "normal_cg",
+        "gpu_cgls": "gpu_cgls",
+    }
+
+    def __init__(self, container, mesh, *, model_constraints=(1e-2, 1e5),
+                 method="cgls", log=_noop_log):
+        try:
+            import adtlert
+            from adtlert.forward import mesh_to_adtlert, survey_to_adtlert
+            from adtlert.inversion import ParameterizedERTForward2p5D
+        except ImportError as exc:
+            raise BackendUnavailable(
+                "The ADTLERT ERT backend is unavailable. Install it with "
+                "`pip install \"pyhydrogeophysx[adtlert]\"`."
+            ) from exc
+
+        if int(mesh.dim()) != 2:
+            raise ValueError(
+                "engine='adtlert' currently supports 2D profile meshes only; "
+                "use engine='pygimli' for this mesh"
+            )
+
+        active_ids = np.asarray(
+            [
+                int(cell.id())
+                for cell in mesh.cells()
+                if int(cell.marker()) > 1
+            ],
+            dtype=np.int32,
+        )
+        if active_ids.size == 0:
+            raise ValueError(
+                "the ADTLERT parameter domain has no cells with marker > 1"
+            )
+
+        # createMeshByCellIdx preserves the full-mesh order used by active_ids.
+        # That same order is used for the ADTLERT model and the manager-shaped
+        # result consumed by the existing VTK and Qt paths.
+        self.mesh = mesh.createMeshByCellIdx(pg.IVector(active_ids.tolist()))
+        forward_mesh = mesh_to_adtlert(mesh)
+        parameter_mesh = mesh_to_adtlert(self.mesh)
+        survey = survey_to_adtlert(container, dimension=2)
+        geometric_mode = (
+            "analytic" if bool(forward_mesh.is_flat_surface) else "numerical"
+        )
+        self._forward = ParameterizedERTForward2p5D.from_mesh_survey(
+            forward_mesh,
+            survey,
+            active_ids,
+            regularization_mesh=parameter_mesh,
+            background_mode="pygimli_prolongation",
+            topographic_geometric_factor_mode=geometric_mode,
+            linear_solver_backend="auto",
+        )
+        self.container = container
+        self._adtlert_version = str(getattr(adtlert, "__version__", ""))
+        self._observed = np.asarray(container["rhoa"], dtype=float)
+        self._errors = np.log1p(np.asarray(container["err"], dtype=float))
+        self._initial_model = np.full(
+            active_ids.size, float(np.median(self._observed)), dtype=float
+        )
+        self._model_constraints = tuple(
+            float(value) for value in model_constraints
+        )
+        solver = self._SOLVERS.get(str(method).lower())
+        if solver is None:
+            choices = ", ".join(sorted(self._SOLVERS))
+            raise ValueError(
+                f"Unknown ADTLERT linearized solver {method!r}; "
+                f"choose one of {choices}."
+            )
+        self._solver = solver
+        log(
+            f"  ADTLERT {self._adtlert_version or '(unknown version)'}: "
+            f"{mesh.cellCount()} forward cells, {active_ids.size} parameters"
+        )
+
+    def reference_model(self):
+        return self._initial_model.copy()
+
+    def fit(self, *, lam, max_iterations, plateau_tolerance, target_chi2,
+            start_model=None, reference_model=None) -> ERTRun:
+        from adtlert.inversion import (
+            InversionConfig,
+            invert_single_log_resistivity,
+        )
+
+        initial = (
+            self._initial_model
+            if start_model is None
+            else np.asarray(start_model, dtype=float)
+        )
+        config = InversionConfig(
+            max_iterations=int(max_iterations),
+            data_std=self._errors,
+            regularization=float(lam),
+            spatial_regularization="first_order",
+            model_bounds=self._model_constraints,
+            target_chi2=float(target_chi2),
+            step_tolerance=float(plateau_tolerance),
+            linearized_solver=self._solver,
+        )
+        inverted = invert_single_log_resistivity(
+            self._forward,
+            self._observed,
+            initial,
+            reference_model=reference_model,
+            config=config,
+        )
+        history = [float(value) for value in inverted.iteration_chi2]
+        chi2 = history[-1] if history else float("nan")
+        iterations = len(history)
+        if np.isfinite(chi2) and chi2 < float(target_chi2):
+            stop = "target"
+        elif iterations >= int(max_iterations):
+            stop = "iteration_cap"
+        else:
+            stop = "plateau"
+        return ERTRun(
+            lam=float(lam),
+            chi2=float(chi2),
+            iterations=iterations,
+            stop=stop,
+            convergence=history,
+            model=np.asarray(inverted.final_model, dtype=float),
+            response=np.asarray(inverted.predicted_data, dtype=float),
+            mesh=self.mesh,
+            coverage=np.asarray(inverted.coverage, dtype=float),
+            metrics={
+                "backend": "adtlert",
+                "backend_version": self._adtlert_version,
+                "chi2": float(chi2),
+                "lambda": float(lam),
+                "iterations": iterations,
+                "n_data": int(self.container.size()),
+            },
+        )
+
+
+ENGINES = {
+    "pyhydro": _PyHydroEngine,
+    "pygimli": _PygimliEngine,
+    "adtlert": _ADTLertEngine,
+}
 
 
 def _make_engine(name: str, container, mesh, **kwargs):
     factory = ENGINES.get(str(name).lower())
     if factory is None:
-        raise ValueError(f"Unknown ERT engine {name!r}; choose one of {sorted(ENGINES)}.")
+        raise ValueError(
+            f"Unknown ERT engine {name!r}; choose one of {sorted(ENGINES)}."
+        )
     return factory(container, mesh, **kwargs)
 
 
@@ -843,7 +1002,8 @@ def run_ert_manager_inversion(
        model down to the data, the direction in which continuation is stable.
 
     ``engine`` selects the solver: ``"pyhydro"`` for the in-house Gauss-Newton
-    inversion (``ERTInversion``), ``"pygimli"`` for ``ert.ERTManager``.
+    inversion (``ERTInversion``), ``"pygimli"`` for ``ert.ERTManager``, or
+    ``"adtlert"`` for the optional differentiable ADTLERT 2.5D backend.
     """
     data, error_info = _prepare_ert_data(
         data_path, relative_error=relative_error, instrument=instrument, log=log,

--- a/PyHydroGeophysX/inversion/windowed.py
+++ b/PyHydroGeophysX/inversion/windowed.py
@@ -10,8 +10,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import pygimli as pg
 from joblib import Parallel, delayed
+from pygimli.physics import ert
 
 from .base import TimeLapseInversionResult
+from .ert_inversion import _adtlert_solver_name, _build_adtlert_forward
 from .time_lapse import TimeLapseERTInversion
 
 
@@ -126,8 +128,16 @@ class WindowedTimeLapseERTInversion:
     Class for windowed time-lapse ERT inversion to handle large temporal datasets.
     """
     
-    def __init__(self, data_dir: str, ert_files: List[str], measurement_times: List[float],
-                window_size: int = 3, mesh: Optional[Union[pg.Mesh, str]] = None, **kwargs):
+    def __init__(
+        self,
+        data_dir: str,
+        ert_files: List[str],
+        measurement_times: List[float],
+        window_size: int = 3,
+        mesh: Optional[Union[pg.Mesh, str]] = None,
+        engine: str = "pyhydro",
+        **kwargs,
+    ):
         """
         Initialize windowed time-lapse ERT inversion.
         
@@ -137,6 +147,7 @@ class WindowedTimeLapseERTInversion:
             measurement_times: List of measurement times
             window_size: Size of sliding window
             mesh: Mesh for inversion or path to mesh file
+            engine: ``"pyhydro"`` or the optional GPU ``"adtlert"`` backend
             **kwargs: Additional parameters to pass to TimeLapseERTInversion
         """
         self.data_dir = data_dir
@@ -144,6 +155,7 @@ class WindowedTimeLapseERTInversion:
         self.measurement_times = np.array(measurement_times)
         self.window_size = window_size
         self.mesh = mesh
+        self.engine = str(engine).lower()
         self.inversion_params = kwargs
         
         # Validate inputs
@@ -164,8 +176,235 @@ class WindowedTimeLapseERTInversion:
         
         # Middle index for extracting results from windows
         self.mid_idx = window_size // 2
+
+    @staticmethod
+    def _survey_arrays(data) -> Tuple[np.ndarray, np.ndarray]:
+        sensors = np.asarray(
+            [[float(pos[0]), float(pos[1])] for pos in data.sensorPositions()],
+            dtype=float,
+        )
+        abmn = np.column_stack(
+            [
+                np.asarray(data[key], dtype=np.int32)
+                for key in ("a", "b", "m", "n")
+            ]
+        )
+        return sensors, abmn
+
+    def _load_adtlert_series(self):
+        paths = [os.path.join(self.data_dir, name) for name in self.ert_files]
+        datasets = [ert.load(path) for path in paths]
+        reference_sensors, reference_abmn = self._survey_arrays(datasets[0])
+        observed_rows = []
+        error_rows = []
+        relative_error = float(
+            self.inversion_params.get("relativeError", 0.05)
+        )
+        absolute_error = float(
+            self.inversion_params.get(
+                "absoluteError",
+                self.inversion_params.get("absoluteUError", 0.0),
+            )
+        )
+
+        for index, data in enumerate(datasets):
+            sensors, abmn = self._survey_arrays(data)
+            if sensors.shape != reference_sensors.shape or not np.allclose(
+                sensors, reference_sensors, rtol=0.0, atol=1.0e-8
+            ):
+                raise ValueError(
+                    "ADTLERT windowed inversion requires identical electrode "
+                    f"positions at every timestep; timestep {index} differs"
+                )
+            if not np.array_equal(abmn, reference_abmn):
+                raise ValueError(
+                    "ADTLERT windowed inversion requires identical ABMN "
+                    "ordering "
+                    f"at every timestep; timestep {index} differs"
+                )
+
+            observed = np.asarray(data["rhoa"], dtype=float)
+            if observed.shape != (reference_abmn.shape[0],):
+                raise ValueError(
+                    f"timestep {index} has {observed.size} apparent "
+                    "resistivities; "
+                    f"expected {reference_abmn.shape[0]}"
+                )
+            if not np.all(np.isfinite(observed)) or np.any(observed <= 0.0):
+                raise ValueError(
+                    f"timestep {index} contains invalid apparent resistivity "
+                    "values"
+                )
+
+            errors = np.asarray(data["err"], dtype=float)
+            invalid_errors = (
+                errors.shape != observed.shape
+                or not np.all(np.isfinite(errors))
+                or np.any(errors <= 0.0)
+            )
+            if invalid_errors:
+                if "r" in data.dataMap():
+                    resistance = np.abs(np.asarray(data["r"], dtype=float))
+                else:
+                    factors = np.abs(np.asarray(data["k"], dtype=float))
+                    resistance = observed / np.maximum(factors, 1.0e-12)
+                errors = relative_error + absolute_error / np.maximum(
+                    resistance, 1.0e-12
+                )
+            observed_rows.append(observed)
+            error_rows.append(np.clip(errors, 0.01, 0.50))
+
+        return datasets, np.vstack(observed_rows), np.vstack(error_rows)
+
+    def _run_adtlert(self) -> TimeLapseInversionResult:
+        try:
+            from adtlert.inversion import (
+                InversionConfig,
+                invert_windowed_timelapse_log_resistivity,
+            )
+        except ImportError as exc:
+            from PyHydroGeophysX._internal.optional_dependencies import (
+                BackendUnavailable,
+            )
+
+            raise BackendUnavailable(
+                "The ADTLERT ERT backend is unavailable. Install it with "
+                "`pip install \"pyhydrogeophysx[adtlert]\"`."
+            ) from exc
+
+        datasets, observed, relative_errors = self._load_adtlert_series()
+        if isinstance(self.mesh, (str, os.PathLike)):
+            mesh = pg.load(str(self.mesh))
+        elif self.mesh is None:
+            mesh = ert.ERTManager(datasets[0]).createMesh(
+                data=datasets[0],
+                quality=float(self.inversion_params.get("mesh_quality", 34.0)),
+            )
+        else:
+            mesh = self.mesh
+
+        forward, result_mesh, active_ids, version = _build_adtlert_forward(
+            datasets[0], mesh
+        )
+        inversion_type = str(
+            self.inversion_params.get("inversion_type", "L2")
+        ).upper()
+        norm_config = {
+            "L2": ("weighted_log_l2", "first_order", "temporal_smoothness"),
+            "L1": ("weighted_log_l1", "first_order_l1", "first_order_l1"),
+            "L1L2": ("weighted_log_huber", "first_order_l1", "first_order_l1"),
+        }
+        try:
+            norm_values = norm_config[inversion_type]
+            data_misfit, spatial_regularization, temporal_regularization = (
+                norm_values
+            )
+        except KeyError as exc:
+            raise ValueError(
+                "ADTLERT windowed inversion_type must be L2, L1 or L1L2"
+            ) from exc
+
+        linearized_solver = _adtlert_solver_name(
+            self.inversion_params.get("method", "cgls"),
+            prefer_gpu=True,
+        )
+        config = InversionConfig(
+            max_iterations=int(
+                self.inversion_params.get("max_iterations", 15)
+            ),
+            data_std=np.log1p(relative_errors),
+            data_misfit=data_misfit,
+            regularization=float(
+                self.inversion_params.get("lambda_val", 50.0)
+            ),
+            spatial_regularization=spatial_regularization,
+            temporal_regularization=float(
+                self.inversion_params.get("alpha", 10.0)
+            ),
+            temporal_regularization_mode="separate",
+            temporal_regularization_type=temporal_regularization,
+            model_bounds=tuple(
+                float(value)
+                for value in self.inversion_params.get(
+                    "model_constraints", (1.0e-2, 1.0e5)
+                )
+            ),
+            target_chi2=float(
+                self.inversion_params.get("target_chi_squared", 1.0)
+            ),
+            step_tolerance=float(
+                self.inversion_params.get("convergence_tolerance", 0.01)
+            ),
+            linearized_solver=linearized_solver,
+        )
+        initial = np.vstack(
+            [
+                np.full(active_ids.size, np.median(row), dtype=float)
+                for row in observed
+            ]
+        ).T
+        inverted = invert_windowed_timelapse_log_resistivity(
+            forward,
+            observed,
+            initial,
+            window_size=int(self.window_size),
+            window_step=int(self.inversion_params.get("window_step", 1)),
+            config=config,
+        )
+
+        result = TimeLapseInversionResult()
+        result.final_models = np.asarray(inverted.final_models, dtype=float)
+        result.predicted_data = np.asarray(
+            inverted.predicted_data, dtype=float
+        )
+        result.coverage = np.asarray(inverted.coverage, dtype=float)
+        result.timesteps = self.measurement_times.copy()
+        result.mesh = result_mesh
+        coverage_by_time: List[List[np.ndarray]] = [
+            [] for _ in range(self.total_steps)
+        ]
+        for report, window_coverage in zip(
+            inverted.window_reports, inverted.all_coverage
+        ):
+            coverage_values = np.asarray(window_coverage, dtype=float)
+            for time_index in range(
+                int(report["start_idx"]), int(report["end_idx"]) + 1
+            ):
+                coverage_by_time[time_index].append(coverage_values)
+        result.all_coverage = [
+            (
+                np.nanmedian(np.vstack(values), axis=0)
+                if values
+                else result.coverage.copy()
+            )
+            for values in coverage_by_time
+        ]
+        result.all_chi2 = [float(value) for value in inverted.all_chi2]
+        result.iteration_chi2 = [
+            float(value) for value in inverted.iteration_chi2
+        ]
+        result.meta.update(
+            backend="adtlert",
+            backend_version=version,
+            chi2=(
+                result.iteration_chi2[-1]
+                if result.iteration_chi2
+                else float("nan")
+            ),
+            iterations=len(result.iteration_chi2),
+            lambda_val=float(config.regularization),
+            window_size=int(self.window_size),
+            window_step=int(self.inversion_params.get("window_step", 1)),
+            linearized_solver=linearized_solver,
+            window_reports=list(inverted.window_reports),
+        )
+        return result
     
-    def run(self, window_parallel: bool = False, max_window_workers: Optional[int] = None) -> TimeLapseInversionResult:
+    def run(
+        self,
+        window_parallel: bool = False,
+        max_window_workers: Optional[int] = None,
+    ) -> TimeLapseInversionResult:
         """
         Run windowed time-lapse ERT inversion.
         
@@ -176,6 +415,18 @@ class WindowedTimeLapseERTInversion:
         Returns:
             TimeLapseInversionResult with stitched results
         """
+        if self.engine == "adtlert":
+            if window_parallel:
+                raise ValueError(
+                    "ADTLERT windowed inversion uses one shared GPU/cuDSS context; "
+                    "window_parallel=True would duplicate GPU memory"
+                )
+            return self._run_adtlert()
+        if self.engine != "pyhydro":
+            raise ValueError(
+                "WindowedTimeLapseERTInversion engine must be 'pyhydro' or 'adtlert'"
+            )
+
         # Initialize result
         result = TimeLapseInversionResult()
         result.timesteps = self.measurement_times

--- a/PyHydroGeophysX/qt_apps/modules/ert_processing.py
+++ b/PyHydroGeophysX/qt_apps/modules/ert_processing.py
@@ -316,12 +316,14 @@ class ERTProcessingModule(BaseModule):
 
         self._engine = QComboBox()
         for label, value in (("In-house Gauss-Newton", "pyhydro"),
-                             ("PyGIMLi ERTManager", "pygimli")):
+                             ("PyGIMLi ERTManager", "pygimli"),
+                             ("ADTLERT differentiable 2.5D", "adtlert")):
             self._engine.addItem(label, value)
         self._engine.setToolTip(
             "Solver. The in-house Gauss-Newton inversion exposes its own stopping rule "
             "and line search, so the fit assistance below can drive it directly; the "
-            "PyGIMLi manager is kept as a cross-check.")
+            "PyGIMLi manager is kept as a cross-check. ADTLERT is an optional "
+            "Torch backend for 2D profiles.")
         iform.addRow("Engine", self._engine)
 
         self._lam = QDoubleSpinBox()
@@ -1815,7 +1817,7 @@ class ERTProcessingModule(BaseModule):
                           "above, and '' goes back to generating it). "
                           "Single-inversion error model: error_source (file/estimate/max), "
                           "absolute_error (Ohm). Convergence: plateau_tolerance (fraction), "
-                          "max_total_iterations, engine (pyhydro/pygimli). "
+                          "max_total_iterations, engine (pyhydro/pygimli/adtlert). "
                           "Geometric factors: geometric_factor_policy "
                           "('fix' recomputes k numerically when a homogeneous forward run "
                           "does not return the model resistivity, 'check' only reports, "

--- a/PyHydroGeophysX/qt_apps/modules/ert_processing.py
+++ b/PyHydroGeophysX/qt_apps/modules/ert_processing.py
@@ -1411,6 +1411,15 @@ class ERTProcessingModule(BaseModule):
         if len(self._tl_files) < 2:
             self.log("Add at least two ordered ERT data files (a time sequence).", "warn")
             return
+        if (
+            self._engine.currentData() == "adtlert"
+            and not self._tl_windowed.isChecked()
+        ):
+            self.log(
+                "ADTLERT time-lapse inversion requires Windowed (sliding window).",
+                "warn",
+            )
+            return
         out_dir = str(self.state.output_dir or Path.cwd())
         instrument = self._instrument.currentData()
         params = {
@@ -1418,6 +1427,7 @@ class ERTProcessingModule(BaseModule):
             "inversion_type": self._tl_type.currentText(), "max_iterations": self._iter.value(),
             "relativeError": self._relerr.value(), "mesh_quality": self._quality.value(),
             "windowed": self._tl_windowed.isChecked(), "window_size": self._tl_window.value(),
+            "engine": str(self._engine.currentData()),
             "instrument": instrument,
             # Same auto-λ switch as the single inversion; the trial budget is
             # smaller because each trial is a joint inversion over every step.
@@ -1501,12 +1511,17 @@ class ERTProcessingModule(BaseModule):
         self._quality_view.show_quality(
             {"chi2": result.get("chi2"), "iterations": len(result.get("chi2_history") or []) or None,
              "n_data": result.get("n_data"), "lambda": self._lam.value(),
-             "method": f"time-lapse {result.get('inversion_type', '')} ({result.get('n_times')} steps)",
-             "note": "Joint χ² over all time steps."},
+             "method": (f"{result.get('engine', 'pyhydro')} time-lapse "
+                        f"{result.get('inversion_type', '')} "
+                        f"({result.get('n_times')} steps)"),
+             "note": ("Joint χ² over all time steps."
+                      + (f" Solver: {result.get('linearized_solver')}."
+                         if result.get("linearized_solver") else ""))},
             result.get("chi2_history"), title="Time-lapse ERT inversion")
         lowmem = " · low-memory" if result.get("save_memory") else ""
         n_vtk = len(result.get("vtk_step_paths") or [])
-        self.log(f"Time-lapse inversion complete ({result.get('mode')}{lowmem}): "
+        self.log(f"Time-lapse inversion complete "
+                 f"({result.get('engine', 'pyhydro')}, {result.get('mode')}{lowmem}): "
                  f"{result.get('n_times')} steps, {result.get('mesh_cells')} cells. "
                  f"Saved VTK (combined + {n_vtk} per-step), npy, mesh. "
                  f"Pick a step in the Resistivity model tab; “Export results…” saves them.", "success")
@@ -1827,7 +1842,8 @@ class ERTProcessingModule(BaseModule):
                           "Auto-lambda: auto_lambda (bool), target_chi2, chi2_tolerance, "
                           "max_lambda_trials. "
                           "Time-lapse-only: tl_alpha, tl_norm (L2/L1/L1L2), tl_windowed, "
-                          "tl_window_size, tl_low_memory.")},
+                          "tl_window_size, tl_low_memory. ADTLERT time-lapse currently "
+                          "requires windowed mode and a common survey geometry.")},
                 {"name": "run_inversion", "args": {},
                  "desc": ("Run a single-time ERT inversion. Stages run in the order that "
                           "lowers chi2: fix the error model, iterate at the set lambda "

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ On Linux, the `adtlert` extra installs the GPU-enabled PyPI Torch distribution
 and ADTLERT's CUDA 12 CuPy/cuDSS solver stack. ADTLERT automatically falls back
 to SciPy when CUDA is unavailable.
 
+ADTLERT can also run the windowed time-lapse workflow on one shared GPU forward
+operator and cuDSS context:
+
+```python
+from PyHydroGeophysX.inversion.time_lapse import run_timelapse_ert
+
+result = run_timelapse_ert(
+    ["survey_0.dat", "survey_1.dat", "survey_2.dat"],
+    [0.0, 1.0, 2.0],
+    {"engine": "adtlert", "windowed": True, "window_size": 3},
+    "output",
+)
+```
+
+All timesteps must use the same electrode positions and ABMN ordering. ADTLERT
+processes overlapping windows sequentially on the GPU so solver state and
+Jacobian caches are reused without duplicating GPU memory across processes.
+The default `cgls` method selects CuPy CGLS when a CUDA device is available and
+falls back to the compatible CPU implementation otherwise.
+
 Do not combine that CUDA 12 extra with `pyhydrogeophysx[gpu]`, which currently
 installs the mutually exclusive `cupy-cuda11x` build.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ pip install pyhydrogeophysx
 # With geophysics engines (ERT/SRT/TDEM/FDEM inversion and forward modeling)
 pip install "pyhydrogeophysx[geophysics]"
 
+# With the optional ADTLERT differentiable 2.5D ERT backend (Python 3.11+)
+pip install "pyhydrogeophysx[adtlert]"
+
 # With AI agent support
 pip install "pyhydrogeophysx[geophysics,agents]"
 
@@ -65,6 +68,26 @@ pip install "pyhydrogeophysx[all]"
 > conda install -c gimli pygimli
 > pip install "pyhydrogeophysx[agents]"  # then add other extras
 > ```
+
+The ADTLERT backend plugs into the existing single-time ERT pipeline without
+changing its default engine:
+
+```python
+from PyHydroGeophysX.inversion.ert_inversion import run_ert_manager_inversion
+
+result = run_ert_manager_inversion(
+    "survey.dat",
+    "output",
+    engine="adtlert",
+)
+```
+
+On Linux, the `adtlert` extra installs the GPU-enabled PyPI Torch distribution
+and ADTLERT's CUDA 12 CuPy/cuDSS solver stack. ADTLERT automatically falls back
+to SciPy when CUDA is unavailable.
+
+Do not combine that CUDA 12 extra with `pyhydrogeophysx[gpu]`, which currently
+installs the mutually exclusive `cupy-cuda11x` build.
 
 ### From Source
 
@@ -108,6 +131,7 @@ Verify when done:
 | Extra | Packages installed |
 |---|---|
 | `geophysics` | pygimli, simpeg, pymatsolver, flopy, pftools |
+| `adtlert` | adtlert, pygimli, GPU-enabled Torch and CUDA 12/cuDSS on Linux (Python 3.11+) |
 | `desktop` | PySide6, pyqtgraph, qtawesome, numpy, pandas |
 | `desktop-3d` | pyvista, pyvistaqt, vtk (the Mesh 3D and volume viewers) |
 | `agents` | openai, google-generativeai, anthropic |
@@ -117,7 +141,7 @@ Verify when done:
 | `gpu` | cupy-cuda11x |
 | `docs` | sphinx, sphinx-gallery, sphinx_rtd_theme |
 | `dev` | pytest, pytest-cov, black, flake8 |
-| `all` | all of the above |
+| `all` | all general-purpose groups above; ADTLERT remains opt-in |
 
 `desktop-3d` is separate because `vtk` is a large binary wheel. Without it the
 workbench runs and exports meshes as usual, and the 3D panels show an install

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added ADTLERT as an optional differentiable 2.5D ERT backend for the unified
+  single-time inversion pipeline, including GPU-enabled Torch and CUDA 12/cuDSS
+  installation plus CPU fallback integration coverage.
 - Consolidated optional-backend failures under the public
   `PyHydroGeophysX.BackendUnavailable` base class. Gravity/magnetics inversion
   failures now inherit from it, so one `except BackendUnavailable` handler can

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 - Added ADTLERT as an optional differentiable 2.5D ERT backend for the unified
-  single-time inversion pipeline, including GPU-enabled Torch and CUDA 12/cuDSS
-  installation plus CPU fallback integration coverage.
+  single-time and windowed time-lapse inversion pipelines, including shared GPU
+  forward/cuDSS state, GPU-enabled Torch and CUDA 12/cuDSS installation, and CPU
+  fallback integration coverage.
 - Consolidated optional-backend failures under the public
   `PyHydroGeophysX.BackendUnavailable` base class. Gravity/magnetics inversion
   failures now inherit from it, so one `except BackendUnavailable` handler can

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,6 +17,37 @@ Install with geophysics engines (recommended)
 
    pip install "pyhydrogeophysx[geophysics]"
 
+Install the optional ADTLERT ERT backend
+----------------------------------------
+
+ADTLERT provides a differentiable 2.5D ERT engine for the existing
+``run_ert_manager_inversion`` pipeline. It requires Python 3.11 or newer and
+is intentionally separate from the general ``geophysics`` extra because it
+also installs PyTorch.
+
+.. code-block:: bash
+
+   pip install "pyhydrogeophysx[adtlert]"
+
+Select it explicitly; the default ERT engine remains unchanged.
+
+.. code-block:: python
+
+   from PyHydroGeophysX.inversion.ert_inversion import run_ert_manager_inversion
+
+   result = run_ert_manager_inversion(
+       "survey.dat",
+       "output",
+       engine="adtlert",
+   )
+
+On Linux, this extra installs the GPU-enabled PyPI Torch distribution and
+ADTLERT's CUDA 12 CuPy/cuDSS solver stack. ADTLERT automatically falls back to
+SciPy when CUDA is unavailable.
+
+Do not combine this with ``pyhydrogeophysx[gpu]``. That extra currently uses
+``cupy-cuda11x``, and two CuPy CUDA variants cannot share one environment.
+
 Install from Source
 -------------------
 
@@ -37,6 +68,7 @@ Optional Dependencies
 ---------------------
 
 - PyGIMLi for ERT/SRT forward and inversion
+- ADTLERT for differentiable 2.5D ERT inversion
 - SimPEG for TDEM/FDEM workflows
 - RESIPY for field ERT data processing
 - CuPy for GPU acceleration

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,6 +45,14 @@ On Linux, this extra installs the GPU-enabled PyPI Torch distribution and
 ADTLERT's CUDA 12 CuPy/cuDSS solver stack. ADTLERT automatically falls back to
 SciPy when CUDA is unavailable.
 
+For long monitoring sequences, select ADTLERT together with windowed
+time-lapse inversion. The backend reuses one forward operator, cuDSS context
+and Jacobian cache across overlapping windows. Every timestep must have the
+same electrode positions and ABMN ordering; process-level window parallelism
+is disabled for ADTLERT to avoid duplicating GPU memory. The default ``cgls``
+method selects CuPy CGLS when CUDA is available and falls back to the compatible
+CPU implementation otherwise.
+
 Do not combine this with ``pyhydrogeophysx[gpu]``. That extra currently uses
 ``cupy-cuda11x``, and two CuPy CUDA variants cannot share one environment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ geophysics = [
     "flopy>=3.5,<4.0",
     "pftools>=1.3",
 ]
+adtlert = [
+    "adtlert[cuda12]>=0.1,<0.2; python_version >= '3.11'",
+    "pygimli>=1.5.5,<2.0; python_version >= '3.11'",
+]
 gpu = [
     "cupy-cuda11x",
 ]

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -1,0 +1,133 @@
+"""Integration coverage for the optional ADTLERT ERT backend."""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygimli")
+pytest.importorskip("adtlert")
+
+import pygimli.meshtools as mt  # noqa: E402
+from pygimli.physics import ert  # noqa: E402
+
+from PyHydroGeophysX._internal.optional_dependencies import (  # noqa: E402
+    BackendUnavailable,
+)
+from PyHydroGeophysX.inversion.ert_inversion import (  # noqa: E402
+    _ADTLertEngine,
+    run_ert_manager_inversion,
+)
+
+
+@pytest.fixture(scope="module")
+def adtlert_case(tmp_path_factory):
+    scheme = ert.createData(elecs=np.linspace(0.0, 23.0, 12), schemeName="dd")
+    world = mt.createWorld(
+        start=[-10.0, 0.0], end=[33.0, -15.0], worldMarker=True
+    )
+    block = mt.createRectangle(start=[9.0, -3.0], end=[15.0, -7.0], marker=2)
+    simulation_mesh = mt.createMesh(
+        mt.mergePLC([world, block]), quality=32, area=1.5
+    )
+    data = ert.simulate(
+        simulation_mesh,
+        res=[[1, 150.0], [2, 35.0]],
+        scheme=scheme,
+        noiseLevel=0.5,
+        noiseAbs=1.0e-5,
+        seed=7,
+        verbose=False,
+    )
+    data.remove(data["rhoa"] <= 0.0)
+    path = tmp_path_factory.mktemp("adtlert") / "line.dat"
+    data.save(str(path))
+    return path, data
+
+
+def test_adtlert_backend_runs_through_the_public_ert_pipeline(
+    adtlert_case, tmp_path: Path
+) -> None:
+    path, data = adtlert_case
+    result = run_ert_manager_inversion(
+        path,
+        tmp_path,
+        engine="adtlert",
+        lam=10.0,
+        max_iterations=1,
+        max_total_iterations=1,
+        auto_lambda=False,
+        geometric_factor_policy="off",
+    )
+
+    manager = result["mgr"]
+    model = np.asarray(manager.model, dtype=float)
+    response = np.asarray(manager.response, dtype=float)
+    coverage = np.asarray(manager.coverage(), dtype=float)
+    assert result["engine"] == "adtlert"
+    assert result["metrics"]["backend"] == "adtlert"
+    assert manager.paraDomain.cellCount() == model.size == coverage.size
+    assert response.shape == (data.size(),)
+    assert np.all(np.isfinite(model))
+    assert np.all(np.isfinite(response))
+    assert np.isfinite(result["chi2"])
+
+
+def test_adtlert_backend_preserves_an_imported_parameter_domain(
+    adtlert_case, tmp_path: Path
+) -> None:
+    path, data = adtlert_case
+    mesh = mt.createMesh(
+        mt.createParaMeshPLC(
+            data.sensorPositions(), paraDepth=10.0, paraDX=0.6, boundary=1.0
+        ),
+        quality=32,
+    )
+    mesh_path = tmp_path / "imported.bms"
+    mesh.save(str(mesh_path))
+
+    result = run_ert_manager_inversion(
+        path,
+        tmp_path / "result",
+        engine="adtlert",
+        mesh_file=str(mesh_path),
+        lam=10.0,
+        max_iterations=1,
+        max_total_iterations=1,
+        auto_lambda=False,
+        geometric_factor_policy="off",
+    )
+
+    expected = sum(1 for cell in mesh.cells() if cell.marker() > 1)
+    manager = result["mgr"]
+    assert manager.paraDomain.cellCount() == expected
+    assert np.asarray(manager.model).shape == (expected,)
+    assert np.asarray(manager.coverage()).shape == (expected,)
+
+
+def test_missing_adtlert_reports_the_install_extra(
+    adtlert_case, monkeypatch
+) -> None:
+    _, data = adtlert_case
+    mesh = mt.createMesh(
+        mt.createParaMeshPLC(
+            data.sensorPositions(), paraDepth=12.0, boundary=1.0
+        ),
+        quality=32,
+    )
+    original_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "adtlert" or name.startswith("adtlert."):
+            raise ModuleNotFoundError(
+                "No module named 'adtlert'", name="adtlert"
+            )
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    pattern = r"pyhydrogeophysx\[adtlert\]"
+    with pytest.raises(BackendUnavailable, match=pattern):
+        _ADTLertEngine(data, mesh)

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -19,7 +19,14 @@ from PyHydroGeophysX._internal.optional_dependencies import (  # noqa: E402
 )
 from PyHydroGeophysX.inversion.ert_inversion import (  # noqa: E402
     _ADTLertEngine,
+    _adtlert_solver_name,
     run_ert_manager_inversion,
+)
+from PyHydroGeophysX.inversion.windowed import (  # noqa: E402
+    WindowedTimeLapseERTInversion,
+)
+from PyHydroGeophysX.inversion.time_lapse import (  # noqa: E402
+    run_timelapse_ert,
 )
 
 
@@ -46,6 +53,44 @@ def adtlert_case(tmp_path_factory):
     path = tmp_path_factory.mktemp("adtlert") / "line.dat"
     data.save(str(path))
     return path, data
+
+
+@pytest.fixture(scope="module")
+def adtlert_timelapse_case(tmp_path_factory):
+    root = tmp_path_factory.mktemp("adtlert_timelapse")
+    scheme = ert.createData(elecs=np.linspace(0.0, 23.0, 12), schemeName="dd")
+    world = mt.createWorld(
+        start=[-10.0, 0.0], end=[33.0, -15.0], worldMarker=True
+    )
+    block = mt.createRectangle(start=[9.0, -3.0], end=[15.0, -7.0], marker=2)
+    simulation_mesh = mt.createMesh(
+        mt.mergePLC([world, block]), quality=32, area=1.5
+    )
+    files = []
+    datasets = []
+    for index, block_resistivity in enumerate((45.0, 55.0, 70.0, 85.0)):
+        data = ert.simulate(
+            simulation_mesh,
+            res=[[1, 150.0], [2, block_resistivity]],
+            scheme=scheme,
+            noiseLevel=0.0,
+            verbose=False,
+        )
+        data["err"] = np.full(data.size(), 0.03)
+        path = root / f"line_{index}.dat"
+        data.save(str(path))
+        files.append(path.name)
+        datasets.append(data)
+    inversion_mesh = mt.createMesh(
+        mt.createParaMeshPLC(
+            datasets[0].sensorPositions(),
+            paraDepth=10.0,
+            paraDX=0.6,
+            boundary=1.0,
+        ),
+        quality=32,
+    )
+    return root, files, datasets, inversion_mesh
 
 
 def test_adtlert_backend_runs_through_the_public_ert_pipeline(
@@ -108,6 +153,107 @@ def test_adtlert_backend_preserves_an_imported_parameter_domain(
     assert np.asarray(manager.coverage()).shape == (expected,)
 
 
+@pytest.mark.parametrize("inversion_type", ["L2", "L1", "L1L2"])
+def test_adtlert_windowed_timelapse_reuses_one_forward_context(
+    adtlert_timelapse_case, inversion_type: str
+) -> None:
+    root, files, datasets, mesh = adtlert_timelapse_case
+    inversion = WindowedTimeLapseERTInversion(
+        data_dir=str(root),
+        ert_files=files,
+        measurement_times=[0.0, 1.0, 2.0, 3.0],
+        window_size=3,
+        mesh=mesh,
+        engine="adtlert",
+        lambda_val=10.0,
+        alpha=2.0,
+        max_iterations=1,
+        inversion_type=inversion_type,
+    )
+
+    result = inversion.run()
+
+    expected_cells = sum(1 for cell in mesh.cells() if cell.marker() > 1)
+    assert result.meta["backend"] == "adtlert"
+    assert result.meta["linearized_solver"] == _adtlert_solver_name(
+        "cgls", prefer_gpu=True
+    )
+    assert result.final_models.shape == (expected_cells, 4)
+    assert result.predicted_data.shape == (4, datasets[0].size())
+    assert result.coverage.shape == (expected_cells,)
+    assert len(result.all_coverage) == 4
+    assert len(result.meta["window_reports"]) == 2
+    assert np.all(np.isfinite(result.final_models))
+    assert np.all(np.isfinite(result.predicted_data))
+
+
+def test_adtlert_windowed_rejects_multiprocess_gpu_contexts(
+    adtlert_timelapse_case,
+) -> None:
+    root, files, _, mesh = adtlert_timelapse_case
+    inversion = WindowedTimeLapseERTInversion(
+        data_dir=str(root),
+        ert_files=files,
+        measurement_times=[0.0, 1.0, 2.0, 3.0],
+        window_size=3,
+        mesh=mesh,
+        engine="adtlert",
+    )
+    with pytest.raises(ValueError, match="shared GPU/cuDSS context"):
+        inversion.run(window_parallel=True)
+
+
+def test_adtlert_windowed_requires_common_abmn_order(
+    adtlert_timelapse_case, tmp_path: Path
+) -> None:
+    root, files, _, mesh = adtlert_timelapse_case
+    changed = ert.load(str(root / files[1]))
+    changed.remove(np.arange(changed.size()) == 0)
+    changed_path = tmp_path / "changed.dat"
+    changed.save(str(changed_path))
+    inversion = WindowedTimeLapseERTInversion(
+        data_dir=str(root),
+        ert_files=[files[0], str(changed_path)],
+        measurement_times=[0.0, 1.0],
+        window_size=2,
+        mesh=mesh,
+        engine="adtlert",
+    )
+    with pytest.raises(ValueError, match="identical ABMN ordering"):
+        inversion.run()
+
+
+def test_adtlert_windowed_runs_through_the_public_timelapse_workflow(
+    adtlert_timelapse_case, tmp_path: Path
+) -> None:
+    root, files, datasets, _ = adtlert_timelapse_case
+    result = run_timelapse_ert(
+        [str(root / name) for name in files[:3]],
+        [0.0, 1.0, 2.0],
+        {
+            "engine": "adtlert",
+            "windowed": True,
+            "window_size": 3,
+            "lambda_val": 10.0,
+            "alpha": 2.0,
+            "max_iterations": 1,
+            "mesh_quality": 32.0,
+        },
+        str(tmp_path),
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "windowed"
+    assert result["engine"] == "adtlert"
+    assert result["linearized_solver"] == _adtlert_solver_name(
+        "cgls", prefer_gpu=True
+    )
+    assert result["n_times"] == 3
+    assert result["final_models"].shape[1] == 3
+    assert result["coverage"].shape == result["final_models"].T.shape
+    assert result["n_data"] == 3 * datasets[0].size()
+
+
 def test_missing_adtlert_reports_the_install_extra(
     adtlert_case, monkeypatch
 ) -> None:
@@ -131,3 +277,17 @@ def test_missing_adtlert_reports_the_install_extra(
     pattern = r"pyhydrogeophysx\[adtlert\]"
     with pytest.raises(BackendUnavailable, match=pattern):
         _ADTLertEngine(data, mesh)
+
+
+def test_windowed_cgls_falls_back_without_cupy(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "cupy" or name.startswith("cupy."):
+            raise ModuleNotFoundError("No module named 'cupy'", name="cupy")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    assert (
+        _adtlert_solver_name("cgls", prefer_gpu=True) == "pyhydro_cgls"
+    )


### PR DESCRIPTION
## Summary

- add ADTLERT to the unified single-time ERT engine registry while preserving the existing PyGIMLi loading, QC, generated/imported mesh, result, VTK, and Qt contracts
- map 2D parameter cells into ADTLERT's 2.5D forward/inversion API, use numerical geometric factors for complex topography, and let ADTLERT auto-select SciPy or cuDSS
- add native ADTLERT windowed time-lapse inversion to the public workflow and desktop UI, with L2/L1/L1L2 norms and per-timestep coverage output
- reuse one GPU forward operator and bounded Jacobian cache across overlapping windows; disable process-level window parallelism to avoid duplicating CUDA/cuDSS state and VRAM
- use CuPy `gpu_cgls` by default for windowed inversion when CUDA is available, with a compatible CPU CGLS fallback
- add a Python 3.11+ `adtlert` extra with GPU-enabled Torch and the CUDA 12 CuPy/cuDSS stack on Linux; keep it separate from `all` and the existing CUDA 11 CuPy extra
- expose the backend in the desktop ERT selector and document installation, GPU behavior, survey requirements, and the CUDA-extra conflict
- add public-pipeline, imported-mesh, windowed workflow, norm mapping, geometry validation, missing-dependency, and CPU fallback coverage

## Validation

- `pytest -q` — 18 passed
- Python compilation, changed-line length, and `git diff --check` checks — passed
- wheel build and `twine check` — passed
- clean installed-wheel GPU smoke test on an RTX 4070 — Torch CUDA 12.8, CuPy CUDA runtime 12.9, `gpu_cgls`, 4 timesteps / 2 overlapping windows / 139 cells in 2.792 s

## Scope

ADTLERT supports single-time and windowed time-lapse inversion for 2D profile meshes using 2.5D physics. Windowed datasets must share identical electrode positions and ABMN ordering. Existing PyHydro/PyGIMLi paths remain available for full time-lapse inversion and other mesh types, and the default ERT engine remains unchanged.
