### PR TITLE
Keep Qt responsive during ERT inversion workflows

### DIFF
--- a/PyHydroGeophysX/inversion/_time_lapse_workflow.py
+++ b/PyHydroGeophysX/inversion/_time_lapse_workflow.py
@@ -383,18 +383,23 @@ def run_timelapse_ert(
     figure_paths.append(str(panel))
 
     # Exports.
-    np.save(out / "final_models.npy", final_models); data_paths.append(str(out / "final_models.npy"))
+    models_path = out / "final_models.npy"
+    np.save(models_path, final_models); data_paths.append(str(models_path))
+    coverage_path = None
     if coverage is not None:
-        np.save(out / "all_coverage.npy", coverage); data_paths.append(str(out / "all_coverage.npy"))
+        coverage_path = out / "all_coverage.npy"
+        np.save(coverage_path, coverage); data_paths.append(str(coverage_path))
     io_utils.write_csv(
         out / "measurement_times.csv",
         [(i, float(times[i]), labels[i] if i < len(labels) else "",
           Path(source_files[i]).name if i < len(source_files) else "") for i in range(n_time)],
         header=["index", "time", "label", "source_file"])
     data_paths.append(str(out / "measurement_times.csv"))
+    mesh_path = out / "timelapse_mesh.bms"
     try:
-        res_mesh.save(str(out / "timelapse_mesh.bms")); data_paths.append(str(out / "timelapse_mesh.bms"))
+        res_mesh.save(str(mesh_path)); data_paths.append(str(mesh_path))
     except Exception as exc:  # noqa: BLE001
+        mesh_path = None
         log(f"Mesh export skipped: {exc}")
     # Per-step VTKs (one resistivity field each) — a clean ParaView time series.
     vtk_step_paths: List[str] = []
@@ -460,6 +465,11 @@ def run_timelapse_ert(
         "normalized_dir": clean_dir,
         "config_path": str(out / "timelapse_config.json"),
         "output_dir": str(out),
+        "model_bundle": {
+            "mesh": str(mesh_path) if mesh_path is not None else "",
+            "models": str(models_path),
+            "coverage": str(coverage_path) if coverage_path is not None else "",
+        },
         # In-memory results for interactive per-step display (a pyGIMLi mesh +
         # arrays; not JSON-serializable, so the UI strips these before publishing).
         "mesh": res_mesh,

--- a/PyHydroGeophysX/inversion/_time_lapse_workflow.py
+++ b/PyHydroGeophysX/inversion/_time_lapse_workflow.py
@@ -283,7 +283,8 @@ def run_timelapse_ert(
             f"window={window_size}, lambda={p['lambda_val']}, alpha={p['alpha']}")
         inversion = WindowedTimeLapseERTInversion(
             data_dir=clean_dir, ert_files=basenames, measurement_times=times,
-            window_size=window_size, mesh=mesh, engine=engine, **inv_kwargs)
+            window_size=window_size, mesh=mesh, engine=engine, log=log,
+            **inv_kwargs)
         result = inversion.run(window_parallel=False)
         mode = "windowed"
     else:

--- a/PyHydroGeophysX/inversion/ert_inversion.py
+++ b/PyHydroGeophysX/inversion/ert_inversion.py
@@ -1006,6 +1006,32 @@ def _export_model_vtk(manager, output_dir: str | Path, filename: str) -> str:
         return ""
 
 
+def _export_model_bundle(manager, output_dir: str | Path, stem: str) -> Dict[str, str]:
+    """Persist the manager-shaped data needed by a viewer in another process."""
+    out = Path(output_dir)
+    paths = {
+        "mesh": out / f"{stem}_mesh.bms",
+        "model": out / f"{stem}_model.npy",
+        "response": out / f"{stem}_response.npy",
+        "coverage": out / f"{stem}_coverage.npy",
+    }
+    manager.paraDomain.save(str(paths["mesh"]))
+    np.save(paths["model"], np.asarray(manager.model, dtype=float))
+    response = getattr(manager, "response", None)
+    if response is None:
+        inverse = getattr(manager, "inv", None)
+        response = getattr(inverse, "response", None)
+    if response is not None:
+        np.save(paths["response"], np.asarray(response, dtype=float))
+    else:
+        paths.pop("response")
+    try:
+        np.save(paths["coverage"], np.asarray(manager.coverage(), dtype=float))
+    except Exception:  # noqa: BLE001 - coverage is optional for the viewer
+        paths.pop("coverage")
+    return {key: str(path) for key, path in paths.items()}
+
+
 
 #: Mesh formats a user can hand the inversion. ``.bms`` is PyGIMLi's own,
 #: ``.msh`` is Gmsh (the usual route for a complex 3D domain), and the rest are
@@ -1412,6 +1438,11 @@ def run_ert_manager_inversion(
         _export_model_vtk(fixed_handle, out, "resistivity_model_fixed_lambda.vtk")
         if keep_fixed else vtk_path
     )
+    model_bundle = _export_model_bundle(primary, out, "resistivity")
+    fixed_model_bundle = (
+        _export_model_bundle(fixed_handle, out, "resistivity_fixed_lambda")
+        if keep_fixed else dict(model_bundle)
+    )
 
     if result["auto_lambda_note"]:
         log(result["auto_lambda_note"])
@@ -1449,6 +1480,7 @@ def run_ert_manager_inversion(
             "mgr": primary,
             "chi2": run.chi2,
             "vtk": vtk_path,
+            "model_bundle": model_bundle,
             "metrics": metrics,
             "convergence": list(run.convergence),
             "fixed_mgr": fixed_handle if keep_fixed else primary,
@@ -1463,6 +1495,7 @@ def run_ert_manager_inversion(
             "fixed_metrics": dict(fixed_run.metrics),
             "fixed_convergence": list(fixed_run.convergence),
             "fixed_vtk_path": fixed_vtk_path,
+            "fixed_model_bundle": fixed_model_bundle,
             "target_chi2": target,
             "chi2_tolerance": tol,
         }

--- a/PyHydroGeophysX/inversion/time_lapse.py
+++ b/PyHydroGeophysX/inversion/time_lapse.py
@@ -563,6 +563,19 @@ class TimeLapseERTInversion(InversionBase):
 
                 # Store iteration data
                 Err_tot.append([chi2_ert, fmert, ftert])
+                progress_callback = self.parameters.get('progress_callback')
+                if callable(progress_callback):
+                    progress_callback({
+                        'event': 'timelapse_iteration_done',
+                        'iteration': int(nn + 1),
+                        'max_iterations': int(self.parameters['max_iterations']),
+                        'irls_iteration': int(irls_iter + 1),
+                        'irls_iterations': int(
+                            1 if inversion_type == 'L2' else irls_iter_max
+                        ),
+                        'chi2': float(chi2_ert),
+                        'dphi': float(dPhi),
+                    })
 
                 # Check for convergence
                 if chi2_ert < target_chi2:

--- a/PyHydroGeophysX/inversion/windowed.py
+++ b/PyHydroGeophysX/inversion/windowed.py
@@ -87,6 +87,72 @@ class _ADTLERTWindowProgress:
             self.log(f"ADTLERT windowed inversion complete: {total}/{total} windows{suffix}")
 
 
+class _PyHydroWindowProgress:
+    """Map one PyHydro window's inner iterations onto global work units."""
+
+    _OUTER_ITERATIONS = {"L1": 5, "L1L2": 8}
+
+    def __init__(
+        self,
+        *,
+        start_idx: int,
+        n_windows: int,
+        window_size: int,
+        inversion_type: str,
+        max_iterations: int,
+        log: Callable[[str], None],
+    ) -> None:
+        self.start_idx = int(start_idx)
+        self.window_index = self.start_idx + 1
+        self.n_windows = int(n_windows)
+        self.window_size = int(window_size)
+        self.inversion_type = str(inversion_type).upper()
+        self.max_iterations = int(max_iterations)
+        outer = self._OUTER_ITERATIONS.get(self.inversion_type, 1)
+        self.slots_per_window = max(1, outer * self.max_iterations)
+        self.total_units = self.n_windows * self.slots_per_window
+        self.log = log
+
+    def start(self) -> None:
+        completed = self.start_idx * self.slots_per_window
+        first_step = self.start_idx + 1
+        last_step = self.start_idx + self.window_size
+        self.log(
+            f"[progress {completed}/{self.total_units}] PyHydro window "
+            f"{self.window_index}/{self.n_windows} started "
+            f"(time steps {first_step}-{last_step})"
+        )
+
+    def __call__(self, event: Dict[str, Any]) -> None:
+        if event.get("event") != "timelapse_iteration_done":
+            return
+        iteration = int(event.get("iteration", 0))
+        irls_iteration = int(event.get("irls_iteration", 1))
+        local_unit = (irls_iteration - 1) * self.max_iterations + iteration
+        current = self.start_idx * self.slots_per_window + local_unit
+        current = max(0, min(current, self.total_units))
+        chi2 = float(event.get("chi2", float("nan")))
+        dphi = float(event.get("dphi", float("nan")))
+        irls = (
+            f", IRLS {irls_iteration}/{int(event.get('irls_iterations', 1))}"
+            if int(event.get("irls_iterations", 1)) > 1 else ""
+        )
+        self.log(
+            f"[progress {current}/{self.total_units}] PyHydro window "
+            f"{self.window_index}/{self.n_windows}{irls}, iteration "
+            f"{iteration}/{self.max_iterations}: chi2 {chi2:.3f}, dPhi {dphi:.3g}"
+        )
+
+    def done(self, *, chi2: Optional[float], iterations: int) -> None:
+        completed = self.window_index * self.slots_per_window
+        suffix = "" if chi2 is None else f", chi2 {float(chi2):.3f}"
+        self.log(
+            f"[progress {completed}/{self.total_units}] PyHydro window "
+            f"{self.window_index}/{self.n_windows} complete "
+            f"({int(iterations)} iterations{suffix})"
+        )
+
+
 # ---------------------------------------------------------------------------
 # process window
 # ---------------------------------------------------------------------------
@@ -126,14 +192,25 @@ def _process_window(start_idx: int, print_lock, data_dir: str, ert_files: List[s
     if isinstance(mesh, (str, os.PathLike)):
         mesh = pg.load(str(mesh))
     
-    if print_lock is not None:
-        print_lock.acquire()
-    try:
-        print(f"\nStarting {inversion_type} inversion for window {start_idx}")
-        sys.stdout.flush()
-    finally:
+    def emit(message: str) -> None:
         if print_lock is not None:
-            print_lock.release()
+            print_lock.acquire()
+        try:
+            print(message, flush=True)
+        finally:
+            if print_lock is not None:
+                print_lock.release()
+
+    n_windows = len(ert_files) - int(window_size) + 1
+    window_progress = _PyHydroWindowProgress(
+        start_idx=start_idx,
+        n_windows=n_windows,
+        window_size=window_size,
+        inversion_type=inversion_type,
+        max_iterations=int(inversion_params.get("max_iterations", 15)),
+        log=emit,
+    )
+    window_progress.start()
     
     try:
         # Get data file paths for this window
@@ -141,11 +218,17 @@ def _process_window(start_idx: int, print_lock, data_dir: str, ert_files: List[s
         window_times = measurement_times[start_idx:start_idx + window_size]
         
         # Create TimeLapseERTInversion instance
+        window_params = dict(inversion_params)
+        window_params["progress_callback"] = window_progress
+        # The callback above is flushed after every completed iteration.  Keep
+        # the legacy verbose prints off so buffered stdout does not later dump
+        # a duplicate block of the same convergence history.
+        window_params["verbose"] = False
         inversion = TimeLapseERTInversion(
             data_files=window_files,
             measurement_times=window_times,
             mesh=mesh,
-            **inversion_params
+            **window_params
         )
         
         # Run inversion
@@ -164,17 +247,13 @@ def _process_window(start_idx: int, print_lock, data_dir: str, ert_files: List[s
             'mesh_nodes': window_result.mesh.nodeCount() if window_result.mesh else None
         }
         
-        if print_lock is not None:
-            print_lock.acquire()
-        try:
-            print(f"\nWindow {start_idx} results:")
-            print(f"Model shape: {window_result.final_models.shape if window_result.final_models is not None else None}")
-            print(f"Coverage available: {window_result.all_coverage is not None}")
-            print(f"Number of iterations: {len(window_result.all_chi2) if window_result.all_chi2 is not None else 0}")
-            sys.stdout.flush()
-        finally:
-            if print_lock is not None:
-                print_lock.release()
+        history = list(window_result.all_chi2 or [])
+        final_chi2 = None
+        if history:
+            final_values = np.asarray(history[-1], dtype=float).ravel()
+            if final_values.size:
+                final_chi2 = float(final_values[0])
+        window_progress.done(chi2=final_chi2, iterations=len(history))
         
         return start_idx, result_dict
         

--- a/PyHydroGeophysX/inversion/windowed.py
+++ b/PyHydroGeophysX/inversion/windowed.py
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 from multiprocessing import Lock
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pygimli as pg
@@ -19,6 +19,72 @@ from .ert_inversion import (
     _resolve_ert_engine,
 )
 from .time_lapse import TimeLapseERTInversion
+
+
+class _ADTLERTWindowProgress:
+    """Forward ADTLERT's structured window events to workflow text logs.
+
+    The ``[progress current/total]`` prefix is deliberately readable on its
+    own and is also recognized by ``ProcessWorkflowWorker`` so the desktop can
+    turn the same line into a determinate progress bar.
+    """
+
+    def __init__(self, log: Callable[[str], None]) -> None:
+        self.log = log
+        self.iteration_chi2: List[float] = []
+        self.window_index = 0
+        self.n_windows = 0
+
+    def __call__(self, event: Dict[str, Any]) -> None:
+        name = str(event.get("event", ""))
+        if name == "windowed_start":
+            self.n_windows = int(event.get("n_windows", 0))
+            n_times = int(event.get("n_times", 0))
+            window_size = int(event.get("window_size", 0))
+            self.log(
+                f"[progress 0/{self.n_windows}] ADTLERT preparing "
+                f"{self.n_windows} windows ({n_times} steps, window={window_size})"
+            )
+        elif name == "window_start":
+            self.window_index = int(event.get("window_index", 0))
+            self.n_windows = int(event.get("n_windows", self.n_windows))
+            start = int(event.get("start_idx", 0)) + 1
+            end = int(event.get("end_idx", start - 1)) + 1
+            self.log(
+                f"ADTLERT window {self.window_index}/{self.n_windows} started "
+                f"(time steps {start}-{end})"
+            )
+        elif name == "timelapse_iteration_done":
+            value = event.get("chi2")
+            if value is None:
+                return
+            chi2 = float(value)
+            self.iteration_chi2.append(chi2)
+            iteration = int(event.get("iteration", 0))
+            maximum = int(event.get("max_iterations", 0))
+            self.log(
+                f"ADTLERT window {self.window_index}/{self.n_windows}, "
+                f"iteration {iteration}/{maximum}: chi2 {chi2:.3f}"
+            )
+        elif name == "window_done":
+            current = int(event.get("window_index", self.window_index))
+            total = int(event.get("n_windows", self.n_windows))
+            value = event.get("final_chi2")
+            suffix = "" if value is None else f", chi2 {float(value):.3f}"
+            self.log(
+                f"[progress {current}/{total}] ADTLERT window "
+                f"{current}/{total} complete{suffix}"
+            )
+        elif name == "windowed_prediction_start":
+            self.log(
+                "ADTLERT windows complete; assembling predictions for "
+                f"{int(event.get('n_times', 0))} time steps"
+            )
+        elif name == "windowed_done":
+            total = int(event.get("n_windows", self.n_windows))
+            value = event.get("final_chi2")
+            suffix = "" if value is None else f", final chi2 {float(value):.3f}"
+            self.log(f"ADTLERT windowed inversion complete: {total}/{total} windows{suffix}")
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +206,7 @@ class WindowedTimeLapseERTInversion:
         window_size: int = 3,
         mesh: Optional[Union[pg.Mesh, str]] = None,
         engine: str = "pyhydro",
+        log: Optional[Callable[[str], None]] = None,
         **kwargs,
     ):
         """
@@ -161,6 +228,7 @@ class WindowedTimeLapseERTInversion:
         self.mesh = mesh
         self.requested_engine = str(engine).lower()
         self.engine = _resolve_ert_engine(self.requested_engine)
+        self.log = log or (lambda _message: None)
         self.inversion_params = kwargs
         
         # Validate inputs
@@ -313,17 +381,7 @@ class WindowedTimeLapseERTInversion:
             self.inversion_params.get("method", "cgls"),
             prefer_gpu=True,
         )
-        iteration_chi2: List[float] = []
-
-        def _capture_progress(event: Dict[str, Any]) -> None:
-            # ADTLERT 0.1.0's windowed result replaces the within-window
-            # iteration history with one final chi2 per window. Capture the
-            # existing progress events so the UI and exports retain the real
-            # convergence trace without patching the dependency.
-            if event.get("event") == "timelapse_iteration_done":
-                value = event.get("chi2")
-                if value is not None:
-                    iteration_chi2.append(float(value))
+        progress = _ADTLERTWindowProgress(self.log)
 
         config = InversionConfig(
             max_iterations=int(
@@ -359,7 +417,7 @@ class WindowedTimeLapseERTInversion:
             include_robin_boundary_derivative=False,
             max_log_step=1.0,
             line_search=True,
-            progress_callback=_capture_progress,
+            progress_callback=progress,
         )
         initial = np.vstack(
             [
@@ -405,8 +463,8 @@ class WindowedTimeLapseERTInversion:
         ]
         result.all_chi2 = [float(value) for value in inverted.all_chi2]
         result.iteration_chi2 = (
-            iteration_chi2
-            if iteration_chi2
+            progress.iteration_chi2
+            if progress.iteration_chi2
             else [float(value) for value in inverted.iteration_chi2]
         )
         result.meta.update(

--- a/PyHydroGeophysX/qt_apps/modules/ert_processing.py
+++ b/PyHydroGeophysX/qt_apps/modules/ert_processing.py
@@ -1677,9 +1677,7 @@ class ERTProcessingModule(BaseModule):
             return
         self._tl_progress.setRange(0, total)
         self._tl_progress.setValue(max(0, min(current, total)))
-        self._tl_progress.setFormat(
-            f"Windows {current}/{total}" if current else f"Preparing {total} windows"
-        )
+        self._tl_progress.setFormat(label or f"Progress {current}/{total}")
 
     def _on_tl_workflow_ok(self, result: WorkflowRunResult) -> None:
         if hasattr(self.state, "update_workflow_result"):

--- a/PyHydroGeophysX/qt_apps/modules/ert_processing.py
+++ b/PyHydroGeophysX/qt_apps/modules/ert_processing.py
@@ -52,11 +52,13 @@ from PyHydroGeophysX.qt_apps.qt_utils import (
 )
 from PyHydroGeophysX.qt_apps.widgets.mesh_view import MeshResultView
 from PyHydroGeophysX.qt_apps.widgets.quality_view import InversionQualityView
-from PyHydroGeophysX.qt_apps.workers import TaskWorker, WorkflowWorker
+from PyHydroGeophysX.qt_apps.workers import (
+    ProcessWorkflowWorker,
+    TaskWorker,
+)
 from PyHydroGeophysX.data_processing.ert_io import save_edited_ert_container
 from PyHydroGeophysX.workflows import (
     ArtifactRef,
-    RunContext,
     WorkflowRunResult,
     WorkflowSpec,
     export_workflow_bundle,
@@ -107,7 +109,7 @@ class ERTProcessingModule(BaseModule):
         self._ert_data = None        # pygimli DataContainerERT for inversion (filtered)
         self._ert_data_full = None   # unfiltered original
         self._qc_mask: Optional[List[bool]] = None
-        self._inv_worker: Optional[WorkflowWorker] = None
+        self._inv_worker: Optional[Any] = None
         self._inv_busy: Optional[BusyStateController] = None
         self._adtlert_probe_worker: Optional[TaskWorker] = None
         self._adtlert_probe_serial = 0
@@ -128,7 +130,7 @@ class ERTProcessingModule(BaseModule):
         self._tl_files: List[str] = []
         self._tl_labels: List[str] = []
         self._tl_times: List[float] = []
-        self._tl_worker: Optional[WorkflowWorker] = None
+        self._tl_worker: Optional[Any] = None
         self._tl_busy: Optional[BusyStateController] = None
         self._tl_recipe_path = ""
         self._tl_out: Optional[str] = None
@@ -1075,9 +1077,16 @@ class ERTProcessingModule(BaseModule):
         self._invert_btn.setText("Inverting…")
         self._inv_progress.setVisible(True)
         self._inv_progress.setRange(0, 0)
-        self._inv_worker = WorkflowWorker(
-            spec,
-            RunContext(project_root=project_root, output_dir=out_path),
+        # Every ERT engine performs long native numerical work.  Run all of
+        # them outside Qt's interpreter: PyGIMLi and the in-house Gauss-Newton
+        # path can retain the GIL, while ADTLERT owns a CUDA context.  The
+        # process-safe model bundle below restores mesh/model/response/coverage
+        # into the interactive viewer when the child exits.
+        self._inv_worker = ProcessWorkflowWorker(
+            recipe_path,
+            project_root,
+            out_path,
+            out_path / "ert_process_result.json",
         )
         self._inv_worker.logged.connect(lambda msg: self.log(msg, "info"))
         self._inv_worker.succeeded.connect(self._on_ert_workflow_ok)
@@ -1097,6 +1106,14 @@ class ERTProcessingModule(BaseModule):
 
     def _on_ert_workflow_ok(self, result: WorkflowRunResult) -> None:
         summary = dict(result.summary)
+        manager = result.objects.get("manager")
+        fixed_manager = result.objects.get("fixed_manager")
+        if manager is None and summary.get("model_bundle"):
+            manager = self._load_model_bundle(summary["model_bundle"])
+        if fixed_manager is None and summary.get("fixed_model_bundle"):
+            fixed_manager = self._load_model_bundle(
+                summary["fixed_model_bundle"]
+            )
         vtk = self._abs_path(summary.get("vtk"))
         if not vtk:
             vtk_ref = next(
@@ -1105,13 +1122,21 @@ class ERTProcessingModule(BaseModule):
             )
             vtk = self._abs_path(vtk_ref.path) if vtk_ref is not None else ""
         payload = {
-            "mgr": result.objects.get("manager"),
+            "mgr": manager,
             "chi2": result.metrics.get("chi2", float("nan")),
             "vtk": vtk,
             "metrics": dict(result.metrics),
-            "convergence": result.objects.get("convergence") or [],
-            "fixed_mgr": result.objects.get("fixed_manager"),
-            "fixed_convergence": result.objects.get("fixed_convergence") or [],
+            "convergence": (
+                result.objects.get("convergence")
+                or summary.get("convergence")
+                or []
+            ),
+            "fixed_mgr": fixed_manager,
+            "fixed_convergence": (
+                result.objects.get("fixed_convergence")
+                or summary.get("fixed_convergence")
+                or []
+            ),
             "fixed_metrics": dict(summary.get("fixed_metrics") or {}),
             "fixed_lambda": dict(summary.get("fixed_lambda") or {}),
             "fixed_vtk": self._abs_path(summary.get("fixed_vtk_path")),
@@ -1137,6 +1162,29 @@ class ERTProcessingModule(BaseModule):
                 result.to_dict(),
                 recipe_path=self._ert_recipe_path,
             )
+
+    def _load_model_bundle(self, bundle: Dict[str, Any]):
+        """Hydrate a process-safe ERT result into the viewer's manager shape."""
+        try:
+            import pygimli as pygimli
+
+            from PyHydroGeophysX.inversion.ert_inversion import ModelResult
+
+            paths = {key: Path(str(value)) for key, value in dict(bundle).items()}
+            mesh = pygimli.load(str(paths["mesh"]))
+            model = np.load(paths["model"], allow_pickle=False)
+            response = (
+                np.load(paths["response"], allow_pickle=False)
+                if "response" in paths else None
+            )
+            coverage = (
+                np.load(paths["coverage"], allow_pickle=False)
+                if "coverage" in paths else None
+            )
+            return ModelResult(mesh, model, response=response, coverage=coverage)
+        except Exception as exc:  # noqa: BLE001 - keep metrics usable on load failure
+            self.log(f"Could not load inversion model files: {exc}", "error")
+            return None
 
     def _on_inversion_ok(self, result: dict) -> None:
         metrics = dict(result.get("metrics") or {})
@@ -1604,9 +1652,16 @@ class ERTProcessingModule(BaseModule):
         self._tl_progress.setVisible(True); self._tl_progress.setRange(0, 0)
         self.log(f"Starting {params['inversion_type']} time-lapse ERT inversion "
                  f"({len(self._tl_files)} steps)…", "info")
-        self._tl_worker = WorkflowWorker(
-            spec,
-            RunContext(project_root=bundle_dir, output_dir=output_base),
+        # Both supported time-lapse engines execute long native/GPU kernels.
+        # Keep every time-lapse run outside Qt's interpreter so PyGIMLi cannot
+        # retain the GIL and ADTLERT cannot monopolize the GUI CUDA context.
+        # This also covers an unavailable ADTLERT request that falls back to
+        # the PyHydro engine inside the workflow process.
+        self._tl_worker = ProcessWorkflowWorker(
+            recipe_path,
+            bundle_dir,
+            output_base,
+            bundle_dir / "ert_timelapse_process_result.json",
         )
         self._tl_worker.logged.connect(lambda m: self.log(m, "info"))
         self._tl_worker.succeeded.connect(self._on_tl_workflow_ok)
@@ -1623,7 +1678,46 @@ class ERTProcessingModule(BaseModule):
                 result.to_dict(),
                 recipe_path=self._tl_recipe_path,
             )
-        self._on_tl_ok(result.legacy_payload())
+        payload = result.legacy_payload()
+        if payload.get("mesh") is None and payload.get("model_bundle"):
+            payload.update(self._load_timelapse_bundle(payload["model_bundle"]))
+        self._on_tl_ok(payload)
+
+    def _load_timelapse_bundle(self, bundle: Dict[str, Any]) -> Dict[str, Any]:
+        """Load process-safe time-lapse arrays for the interactive Qt viewer."""
+        try:
+            import pygimli as pygimli
+
+            base = (
+                Path(self._tl_recipe_path).resolve().parent
+                if self._tl_recipe_path else Path.cwd()
+            )
+
+            def resolve(value: Any) -> Path:
+                path = Path(str(value))
+                return path if path.is_absolute() else base / path
+
+            paths = dict(bundle)
+            mesh_path = resolve(paths.get("mesh", ""))
+            models_path = resolve(paths.get("models", ""))
+            if not mesh_path.is_file() or not models_path.is_file():
+                raise FileNotFoundError(
+                    f"missing mesh or model bundle ({mesh_path}, {models_path})"
+                )
+            coverage_path = resolve(paths.get("coverage", ""))
+            return {
+                "mesh": pygimli.load(str(mesh_path)),
+                "final_models": np.load(
+                    models_path, allow_pickle=False, mmap_mode="r"
+                ),
+                "coverage": (
+                    np.load(coverage_path, allow_pickle=False, mmap_mode="r")
+                    if coverage_path.is_file() else None
+                ),
+            }
+        except Exception as exc:  # noqa: BLE001 - retain scalar results on failure
+            self.log(f"Could not load time-lapse model files: {exc}", "error")
+            return {"mesh": None, "final_models": None, "coverage": None}
 
     def _on_tl_ok(self, result: dict) -> None:
         # Pull out the in-memory mesh + models for the interactive viewer, then

--- a/PyHydroGeophysX/qt_apps/modules/ert_processing.py
+++ b/PyHydroGeophysX/qt_apps/modules/ert_processing.py
@@ -1664,11 +1664,22 @@ class ERTProcessingModule(BaseModule):
             bundle_dir / "ert_timelapse_process_result.json",
         )
         self._tl_worker.logged.connect(lambda m: self.log(m, "info"))
+        self._tl_worker.progressed.connect(self._on_tl_progress)
         self._tl_worker.succeeded.connect(self._on_tl_workflow_ok)
         self._tl_worker.failed.connect(lambda message: self._on_tl_failed(message, False))
         self._tl_worker.finished.connect(self._reset_tl_button)
         self.register_worker(self._tl_worker)
         self._tl_worker.start()
+
+    def _on_tl_progress(self, current: int, total: int, label: str) -> None:
+        """Show completed ADTLERT windows while retaining the text log."""
+        if total <= 0:
+            return
+        self._tl_progress.setRange(0, total)
+        self._tl_progress.setValue(max(0, min(current, total)))
+        self._tl_progress.setFormat(
+            f"Windows {current}/{total}" if current else f"Preparing {total} windows"
+        )
 
     def _on_tl_workflow_ok(self, result: WorkflowRunResult) -> None:
         if hasattr(self.state, "update_workflow_result"):

--- a/PyHydroGeophysX/qt_apps/workers.py
+++ b/PyHydroGeophysX/qt_apps/workers.py
@@ -1,18 +1,34 @@
 """Generic background worker for the workbench.
 
 ``TaskWorker`` handles non-workflow support tasks such as file parsing and
-preview generation. ``WorkflowWorker`` is the single Qt adapter for registered
-scientific workflows.
+preview generation. ``WorkflowWorker`` runs cooperative workflows in a Qt
+thread, while ``ProcessWorkflowWorker`` isolates native calls that can retain
+the GIL (notably PyGIMLi inversion) in a separate Python process.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+import sys
 from typing import Any, Callable
 
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import (
+    QObject,
+    QProcess,
+    QProcessEnvironment,
+    QThread,
+    QTimer,
+    Signal,
+)
 
 from PyHydroGeophysX._internal.optional_dependencies import BackendUnavailable
-from PyHydroGeophysX.workflows import RunContext, WorkflowSpec, run_workflow
+from PyHydroGeophysX.workflows import (
+    RunContext,
+    WorkflowRunResult,
+    WorkflowSpec,
+    run_workflow,
+)
 
 
 def _error_message(exc: Exception) -> str:
@@ -97,4 +113,166 @@ class WorkflowWorker(QThread):
                 self.failed.emit(_error_message(exc))
 
 
-__all__ = ["TaskWorker", "WorkflowWorker"]
+class ProcessWorkflowWorker(QObject):
+    """Execute a recipe in an isolated Python process.
+
+    A ``QThread`` still shares the interpreter and GIL with Qt's event loop.
+    Some long-running extension calls do not release that GIL often enough, so
+    the window stops painting even though the workflow is nominally off-thread.
+    ``QProcess`` gives the workflow its own interpreter and makes cancellation
+    enforceable without terminating the workbench.
+    """
+
+    succeeded = Signal(object)
+    failed = Signal(str)
+    logged = Signal(str)
+    finished = Signal()
+
+    def __init__(
+        self,
+        recipe_path: str | Path,
+        project_root: str | Path,
+        output_dir: str | Path,
+        result_path: str | Path,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.recipe_path = Path(recipe_path).resolve()
+        self.project_root = Path(project_root).resolve()
+        self.output_dir = Path(output_dir).resolve()
+        self.result_path = Path(result_path).resolve()
+        self._cancelled = False
+        self._finished = False
+
+        self.process = QProcess(self)
+        self.process.setWorkingDirectory(str(self.project_root))
+        # A GUI process on Chinese Windows can give redirected Python streams
+        # the system GBK encoding.  Workflow logs legitimately contain Unicode
+        # text such as ``chi²`` and an ellipsis; printing either would then raise
+        # UnicodeEncodeError after a successful inversion.  Make the child's
+        # encoder match the UTF-8 decoder used by ``_emit_output`` below.
+        environment = QProcessEnvironment.systemEnvironment()
+        environment.insert("PYTHONUTF8", "1")
+        environment.insert("PYTHONIOENCODING", "utf-8")
+        self.process.setProcessEnvironment(environment)
+        # ``sys.executable`` can resolve to the Windows Store base executable
+        # even when the workbench was launched through ``.venv\Scripts``.  A
+        # direct QProcess launch of that MSIX executable bypasses the venv
+        # launcher and has crashed in extension DLL initialization (notably
+        # pyarrow/arrow.dll).  Prefer the console launcher belonging to the
+        # active prefix; QProcess supplies pipes so it does not open a console.
+        prefix_python = Path(sys.prefix) / "Scripts" / "python.exe"
+        executable = prefix_python if prefix_python.is_file() else Path(sys.executable)
+        if executable.name.lower().startswith("pythonw"):
+            console_python = executable.with_name(
+                executable.name.replace("pythonw", "python", 1)
+            )
+            if console_python.is_file():
+                executable = console_python
+        self.process.setProgram(str(executable))
+        self.process.setArguments([
+            "-m",
+            "PyHydroGeophysX.workflows.cli",
+            "run",
+            str(self.recipe_path),
+            "--project-root",
+            str(self.project_root),
+            "--output-dir",
+            str(self.output_dir),
+            "--result-file",
+            str(self.result_path),
+        ])
+        self.process.readyReadStandardOutput.connect(self._read_stdout)
+        self.process.readyReadStandardError.connect(self._read_stderr)
+        self.process.errorOccurred.connect(self._on_process_error)
+        self.process.finished.connect(self._on_finished)
+
+    def start(self) -> None:
+        self.result_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.result_path.unlink()
+        except FileNotFoundError:
+            pass
+        self.process.start()
+
+    def cancel(self) -> None:
+        self._cancelled = True
+        if self.isRunning():
+            self.process.terminate()
+            QTimer.singleShot(2000, self._kill_if_running)
+
+    def quit(self) -> None:
+        """QThread-compatible shutdown hook used by ``BaseModule``."""
+        self.cancel()
+
+    def wait(self, timeout_ms: int = 30000) -> bool:
+        return bool(self.process.waitForFinished(int(timeout_ms)))
+
+    def isRunning(self) -> bool:  # noqa: N802 - mirror QThread's public API
+        return self.process.state() != QProcess.ProcessState.NotRunning
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled
+
+    def _kill_if_running(self) -> None:
+        if self.isRunning():
+            self.process.kill()
+
+    def _emit_output(self, raw: bytes) -> None:
+        text = raw.decode("utf-8", errors="replace")
+        for line in text.splitlines():
+            if line.strip():
+                self.logged.emit(line.rstrip())
+
+    def _read_stdout(self) -> None:
+        self._emit_output(bytes(self.process.readAllStandardOutput()))
+
+    def _read_stderr(self) -> None:
+        self._emit_output(bytes(self.process.readAllStandardError()))
+
+    def _on_process_error(self, error: QProcess.ProcessError) -> None:
+        if error == QProcess.ProcessError.FailedToStart and not self._finished:
+            self._finish_with_error(
+                f"Could not start workflow process: {self.process.errorString()}"
+            )
+
+    def _finish_with_error(self, message: str) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if not self._cancelled:
+            self.failed.emit(message)
+        self.finished.emit()
+
+    def _on_finished(
+        self, exit_code: int, _exit_status: QProcess.ExitStatus
+    ) -> None:
+        if self._finished:
+            return
+        self._read_stdout()
+        self._read_stderr()
+        if self._cancelled:
+            self._finished = True
+            self.finished.emit()
+            return
+        if int(exit_code) != 0:
+            unsigned = int(exit_code) & 0xFFFFFFFF
+            self._finish_with_error(
+                f"Workflow process exited with code {int(exit_code)} "
+                f"(0x{unsigned:08X})."
+            )
+            return
+        try:
+            payload = json.loads(self.result_path.read_text(encoding="utf-8"))
+            result = WorkflowRunResult.from_dict(payload)
+        except Exception as exc:  # noqa: BLE001 - report malformed child output
+            self._finish_with_error(
+                f"Could not read workflow result {self.result_path}: {exc}"
+            )
+            return
+        self._finished = True
+        self.succeeded.emit(result)
+        self.finished.emit()
+
+
+__all__ = ["ProcessWorkflowWorker", "TaskWorker", "WorkflowWorker"]

--- a/PyHydroGeophysX/qt_apps/workers.py
+++ b/PyHydroGeophysX/qt_apps/workers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import sys
 from typing import Any, Callable
 
@@ -126,6 +127,7 @@ class ProcessWorkflowWorker(QObject):
     succeeded = Signal(object)
     failed = Signal(str)
     logged = Signal(str)
+    progressed = Signal(int, int, str)
     finished = Signal()
 
     def __init__(
@@ -221,8 +223,19 @@ class ProcessWorkflowWorker(QObject):
     def _emit_output(self, raw: bytes) -> None:
         text = raw.decode("utf-8", errors="replace")
         for line in text.splitlines():
-            if line.strip():
-                self.logged.emit(line.rstrip())
+            rendered = line.rstrip()
+            if not rendered.strip():
+                continue
+            match = re.match(
+                r"^\[progress\s+(\d+)/(\d+)\]\s*(.*)$", rendered.strip()
+            )
+            if match is not None:
+                current, total = int(match.group(1)), int(match.group(2))
+                label = match.group(3).strip()
+                if total > 0 and 0 <= current <= total:
+                    self.progressed.emit(current, total, label)
+                rendered = label or rendered
+            self.logged.emit(rendered)
 
     def _read_stdout(self) -> None:
         self._emit_output(bytes(self.process.readAllStandardOutput()))

--- a/PyHydroGeophysX/workflows/cli.py
+++ b/PyHydroGeophysX/workflows/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 from typing import Sequence
 
 from .codegen import generate_python
@@ -24,6 +25,11 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("recipe", type=Path)
     run.add_argument("--project-root", type=Path)
     run.add_argument("--output-dir", type=Path)
+    run.add_argument(
+        "--result-file",
+        type=Path,
+        help="Write the process-safe result JSON here instead of stdout.",
+    )
     export = subparsers.add_parser("export-code", help="Generate Python from a recipe.")
     export.add_argument("recipe", type=Path)
     export.add_argument("--output", type=Path, required=True)
@@ -44,12 +50,49 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(generate_python(spec, args.output))
         return 0
     recipe_dir = args.recipe.resolve().parent
-    context = RunContext(
-        project_root=(args.project_root or recipe_dir),
-        output_dir=(args.output_dir or recipe_dir / "results"),
+    progress = (
+        (lambda message: print(str(message), flush=True))
+        if args.result_file is not None
+        else None
     )
-    result = run_workflow(spec, context)
-    print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    context_kwargs = {
+        "project_root": (args.project_root or recipe_dir),
+        "output_dir": (args.output_dir or recipe_dir / "results"),
+    }
+    if progress is not None:
+        context_kwargs["progress"] = progress
+    context = RunContext(
+        **context_kwargs,
+    )
+    # ERT's embedded instrument parsers use pandas but never pyarrow.  Loading
+    # the optional Arrow DLL in a QProcess child has produced native access
+    # violations on Microsoft Store Python.  Make that unused optional backend
+    # look unavailable only for the lifetime of an isolated ERT workflow; this
+    # leaves ordinary CLI and Streamlit/Arrow use untouched.
+    missing = object()
+    previous_pyarrow = missing
+    block_pyarrow = (
+        args.result_file is not None
+        and str(getattr(spec, "workflow_id", "")).startswith("ert.")
+    )
+    if block_pyarrow:
+        previous_pyarrow = sys.modules.get("pyarrow", missing)
+        if previous_pyarrow is missing:
+            sys.modules["pyarrow"] = None
+    try:
+        result = run_workflow(spec, context)
+    finally:
+        if block_pyarrow and previous_pyarrow is missing:
+            sys.modules.pop("pyarrow", None)
+    payload = json.dumps(result.to_dict(), indent=2, sort_keys=True)
+    if args.result_file is not None:
+        destination = args.result_file.resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(destination.name + ".tmp")
+        temporary.write_text(payload, encoding="utf-8")
+        temporary.replace(destination)
+    else:
+        print(payload)
     return 0 if result.status in {"ok", "completed", "success"} else 1
 
 

--- a/PyHydroGeophysX/workflows/domain.py
+++ b/PyHydroGeophysX/workflows/domain.py
@@ -246,6 +246,15 @@ def run_ert_single(spec: WorkflowSpec, context: RunContext) -> WorkflowRunResult
     if not isinstance(source, ArtifactRef):
         raise ValueError("ert.single_inversion requires inputs.data as an ArtifactRef.")
     parameters = dict(spec.parameters)
+    # The desktop workflow has already serialized its edited/QC-filtered
+    # container in pygimli's native unified format.  Re-running the original
+    # instrument parser here is both redundant and harmful in an isolated
+    # process: the BERT parser imports pandas/pyarrow even though no tabular
+    # conversion remains to do.  On Windows Store Python, arrow.dll has crashed
+    # during that unnecessary second parse.  Raw public workflow inputs still
+    # retain the caller-selected instrument parser.
+    normalized_input = bool((source.metadata or {}).get("qc_filtered", False))
+    instrument = None if normalized_input else parameters.get("instrument")
     result = run_ert_manager_inversion(
         context.resolve_artifact(source),
         context.output_dir,
@@ -264,7 +273,7 @@ def run_ert_single(spec: WorkflowSpec, context: RunContext) -> WorkflowRunResult
         geometric_factor_policy=str(parameters.get("geometric_factor_policy", "fix")),
         geometric_factor_tolerance=float(
             parameters.get("geometric_factor_tolerance", 0.05)),
-        instrument=parameters.get("instrument"),
+        instrument=instrument,
         reject_outliers=bool(parameters.get("reject_outliers", False)),
         outlier_threshold=float(parameters.get("outlier_threshold", 3.0)),
         outlier_passes=int(parameters.get("outlier_passes", 2)),
@@ -284,10 +293,10 @@ def run_ert_single(spec: WorkflowSpec, context: RunContext) -> WorkflowRunResult
     fixed_manager = workflow_result.objects.pop("fixed_mgr", None)
     if fixed_manager is not None:
         workflow_result.objects["fixed_manager"] = fixed_manager
-    convergence = workflow_result.summary.pop("convergence", [])
+    convergence = list(workflow_result.summary.get("convergence", []) or [])
     workflow_result.objects["convergence"] = convergence
-    workflow_result.objects["fixed_convergence"] = workflow_result.summary.pop(
-        "fixed_convergence", []
+    workflow_result.objects["fixed_convergence"] = list(
+        workflow_result.summary.get("fixed_convergence", []) or []
     )
     return workflow_result
 

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -310,6 +310,13 @@ def test_adtlert_windowed_runs_through_the_public_timelapse_workflow(
     assert result["final_models"].shape[1] == 3
     assert result["coverage"].shape == result["final_models"].T.shape
     assert result["n_data"] == 3 * datasets[0].size()
+    bundle = result["model_bundle"]
+    restored_mesh = ert_inversion.pg.load(bundle["mesh"])
+    restored_models = np.load(bundle["models"], allow_pickle=False)
+    restored_coverage = np.load(bundle["coverage"], allow_pickle=False)
+    assert restored_mesh.cellCount() == result["mesh"].cellCount()
+    np.testing.assert_allclose(restored_models, result["final_models"])
+    np.testing.assert_allclose(restored_coverage, result["coverage"])
 
 
 def test_missing_adtlert_reports_the_install_extra(

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -30,10 +30,52 @@ from PyHydroGeophysX.inversion.ert_inversion import (  # noqa: E402
 )
 from PyHydroGeophysX.inversion.windowed import (  # noqa: E402
     WindowedTimeLapseERTInversion,
+    _ADTLERTWindowProgress,
 )
 from PyHydroGeophysX.inversion.time_lapse import (  # noqa: E402
     run_timelapse_ert,
 )
+
+
+def test_adtlert_window_events_are_forwarded_as_readable_progress() -> None:
+    messages = []
+    progress = _ADTLERTWindowProgress(messages.append)
+
+    progress({
+        "event": "windowed_start",
+        "n_windows": 8,
+        "n_times": 10,
+        "window_size": 3,
+    })
+    progress({
+        "event": "window_start",
+        "window_index": 1,
+        "n_windows": 8,
+        "start_idx": 0,
+        "end_idx": 2,
+    })
+    progress({
+        "event": "timelapse_iteration_done",
+        "iteration": 2,
+        "max_iterations": 5,
+        "chi2": 1.2345,
+    })
+    progress({
+        "event": "window_done",
+        "window_index": 1,
+        "n_windows": 8,
+        "final_chi2": 1.2,
+    })
+    progress({"event": "windowed_prediction_start", "n_times": 10})
+    progress({"event": "windowed_done", "n_windows": 8, "final_chi2": 0.9})
+
+    assert messages[0].startswith("[progress 0/8]")
+    assert "window 1/8 started (time steps 1-3)" in messages[1]
+    assert "window 1/8, iteration 2/5: chi2 1.234" in messages[2]
+    assert messages[3].startswith("[progress 1/8]")
+    assert "assembling predictions for 10 time steps" in messages[4]
+    assert "complete: 8/8 windows, final chi2 0.900" in messages[5]
+    assert progress.iteration_chi2 == [1.2345]
 
 
 requires_adtlert_cuda = pytest.mark.skipif(
@@ -285,6 +327,7 @@ def test_adtlert_windowed_runs_through_the_public_timelapse_workflow(
     adtlert_timelapse_case, tmp_path: Path
 ) -> None:
     root, files, datasets, _ = adtlert_timelapse_case
+    messages = []
     result = run_timelapse_ert(
         [str(root / name) for name in files[:3]],
         [0.0, 1.0, 2.0],
@@ -298,6 +341,7 @@ def test_adtlert_windowed_runs_through_the_public_timelapse_workflow(
             "mesh_quality": 32.0,
         },
         str(tmp_path),
+        log=messages.append,
     )
 
     assert result["status"] == "ok"
@@ -317,6 +361,9 @@ def test_adtlert_windowed_runs_through_the_public_timelapse_workflow(
     assert restored_mesh.cellCount() == result["mesh"].cellCount()
     np.testing.assert_allclose(restored_models, result["final_models"])
     np.testing.assert_allclose(restored_coverage, result["coverage"])
+    assert any(message.startswith("[progress 0/1]") for message in messages)
+    assert any(message.startswith("[progress 1/1]") for message in messages)
+    assert any("window 1/1 started" in message for message in messages)
 
 
 def test_missing_adtlert_reports_the_install_extra(

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -31,6 +31,7 @@ from PyHydroGeophysX.inversion.ert_inversion import (  # noqa: E402
 from PyHydroGeophysX.inversion.windowed import (  # noqa: E402
     WindowedTimeLapseERTInversion,
     _ADTLERTWindowProgress,
+    _PyHydroWindowProgress,
 )
 from PyHydroGeophysX.inversion.time_lapse import (  # noqa: E402
     run_timelapse_ert,
@@ -76,6 +77,37 @@ def test_adtlert_window_events_are_forwarded_as_readable_progress() -> None:
     assert "assembling predictions for 10 time steps" in messages[4]
     assert "complete: 8/8 windows, final chi2 0.900" in messages[5]
     assert progress.iteration_chi2 == [1.2345]
+
+
+def test_pyhydro_window_iterations_map_to_global_progress_units() -> None:
+    messages = []
+    progress = _PyHydroWindowProgress(
+        start_idx=0,
+        n_windows=8,
+        window_size=3,
+        inversion_type="L2",
+        max_iterations=5,
+        log=messages.append,
+    )
+
+    progress.start()
+    progress({
+        "event": "timelapse_iteration_done",
+        "iteration": 2,
+        "max_iterations": 5,
+        "irls_iteration": 1,
+        "irls_iterations": 1,
+        "chi2": 2.3456,
+        "dphi": 0.125,
+    })
+    progress.done(chi2=2.1, iterations=2)
+
+    assert messages[0].startswith("[progress 0/40]")
+    assert "window 1/8 started (time steps 1-3)" in messages[0]
+    assert messages[1].startswith("[progress 2/40]")
+    assert "iteration 2/5: chi2 2.346, dPhi 0.125" in messages[1]
+    assert messages[2].startswith("[progress 5/40]")
+    assert "window 1/8 complete (2 iterations, chi2 2.100)" in messages[2]
 
 
 requires_adtlert_cuda = pytest.mark.skipif(

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -1,0 +1,203 @@
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+from PySide6.QtCore import QProcess
+
+from PyHydroGeophysX.inversion.ert_inversion import _export_model_bundle
+from PyHydroGeophysX.qt_apps.workers import ProcessWorkflowWorker
+from PyHydroGeophysX.workflows import (
+    ArtifactRef,
+    RunContext,
+    WorkflowRunResult,
+    WorkflowSpec,
+)
+from PyHydroGeophysX.workflows import cli
+from PyHydroGeophysX.workflows import domain
+
+
+def test_cli_writes_process_safe_result_file(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    recipe = tmp_path / "recipe.json"
+    recipe.write_text("{}", encoding="utf-8")
+    result_path = tmp_path / "result.json"
+    expected = WorkflowRunResult(
+        status="success",
+        summary={"engine": "pygimli"},
+        metrics={"chi2": 1.25},
+    )
+
+    monkeypatch.setattr(cli, "load_recipe", lambda _path: object())
+    def fake_run(_spec, context):
+        context.progress("Building inversion mesh")
+        context.progress("Lambda trial 1")
+        return expected
+
+    monkeypatch.setattr(cli, "run_workflow", fake_run)
+
+    exit_code = cli.main([
+        "run",
+        str(recipe),
+        "--output-dir",
+        str(tmp_path / "output"),
+        "--result-file",
+        str(result_path),
+    ])
+
+    assert exit_code == 0
+    assert json.loads(result_path.read_text(encoding="utf-8")) == expected.to_dict()
+    assert not result_path.with_name(result_path.name + ".tmp").exists()
+    output = capsys.readouterr().out
+    assert "Building inversion mesh" in output
+    assert "Lambda trial 1" in output
+
+
+def test_process_worker_restores_result_from_json(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.json"
+    expected = WorkflowRunResult(
+        status="success",
+        summary={"engine": "pygimli"},
+        metrics={"chi2": 0.9},
+    )
+    result_path.write_text(json.dumps(expected.to_dict()), encoding="utf-8")
+    worker = ProcessWorkflowWorker(
+        tmp_path / "recipe.json",
+        tmp_path,
+        tmp_path / "output",
+        result_path,
+    )
+    environment = worker.process.processEnvironment()
+    assert environment.value("PYTHONUTF8") == "1"
+    assert environment.value("PYTHONIOENCODING") == "utf-8"
+    received = []
+    worker.succeeded.connect(received.append)
+
+    prefix_python = Path(sys.prefix) / "Scripts" / "python.exe"
+    if prefix_python.is_file():
+        assert Path(worker.process.program()) == prefix_python
+
+    worker._on_finished(0, QProcess.ExitStatus.NormalExit)
+
+    assert len(received) == 1
+    assert received[0].to_dict() == expected.to_dict()
+
+
+def test_isolated_ert_cli_does_not_load_unused_pyarrow(
+    monkeypatch, tmp_path: Path
+) -> None:
+    recipe = tmp_path / "recipe.json"
+    recipe.write_text("{}", encoding="utf-8")
+    result_path = tmp_path / "result.json"
+    seen = []
+    monkeypatch.delitem(sys.modules, "pyarrow", raising=False)
+    monkeypatch.setattr(
+        cli,
+        "load_recipe",
+        lambda _path: SimpleNamespace(workflow_id="ert.timelapse_inversion"),
+    )
+
+    def fake_run(_spec, _context):
+        seen.append(sys.modules.get("pyarrow", "missing"))
+        return WorkflowRunResult(status="success")
+
+    monkeypatch.setattr(cli, "run_workflow", fake_run)
+
+    assert cli.main([
+        "run",
+        str(recipe),
+        "--result-file",
+        str(result_path),
+    ]) == 0
+    assert seen == [None]
+    assert "pyarrow" not in sys.modules
+
+
+def test_export_model_bundle_persists_process_safe_arrays(tmp_path: Path) -> None:
+    class Mesh:
+        def save(self, path: str) -> None:
+            Path(path).write_text("mesh", encoding="utf-8")
+
+    class Manager:
+        paraDomain = Mesh()
+        model = np.array([10.0, 20.0])
+        response = np.array([12.0, 18.0, 21.0])
+
+        @staticmethod
+        def coverage():
+            return np.array([-2.0, 0.5])
+
+    bundle = _export_model_bundle(Manager(), tmp_path, "resistivity")
+
+    assert Path(bundle["mesh"]).is_file()
+    np.testing.assert_allclose(np.load(bundle["model"]), Manager.model)
+    np.testing.assert_allclose(np.load(bundle["response"]), Manager.response)
+    np.testing.assert_allclose(np.load(bundle["coverage"]), Manager.coverage())
+
+
+def test_model_bundle_round_trips_a_pygimli_mesh(tmp_path: Path) -> None:
+    import pygimli as pygimli
+    import pygimli.meshtools as mt
+
+    from PyHydroGeophysX.inversion.ert_inversion import ModelResult
+
+    mesh = mt.createMesh(
+        mt.createRectangle(start=[0.0, 0.0], end=[2.0, -1.0]),
+        quality=30,
+        area=0.2,
+    )
+    model = np.linspace(10.0, 20.0, mesh.cellCount())
+    coverage = np.linspace(-2.0, 1.0, mesh.cellCount())
+    bundle = _export_model_bundle(
+        ModelResult(mesh, model, coverage=coverage),
+        tmp_path,
+        "roundtrip",
+    )
+
+    loaded_mesh = pygimli.load(bundle["mesh"])
+    assert loaded_mesh.cellCount() == mesh.cellCount()
+    np.testing.assert_allclose(np.load(bundle["model"]), model)
+    np.testing.assert_allclose(np.load(bundle["coverage"]), coverage)
+
+
+def test_normalized_ert_workflow_skips_the_instrument_parser(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from PyHydroGeophysX.inversion import ert_inversion
+
+    data_path = tmp_path / "filtered.dat"
+    data_path.write_text("normalized", encoding="utf-8")
+    source = ArtifactRef.from_path(
+        data_path,
+        artifact_id="ert:filtered",
+        kind="ert_data",
+        base_dir=tmp_path,
+        metadata={"qc_filtered": True},
+    )
+    captured = {}
+
+    def fake_run(_data_path, _output_dir, **kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "success",
+            "engine": "pygimli",
+            "metrics": {"chi2": 1.0},
+            "convergence": [2.0, 1.0],
+        }
+
+    monkeypatch.setattr(ert_inversion, "run_ert_manager_inversion", fake_run)
+    spec = WorkflowSpec(
+        workflow_id="ert.single_inversion",
+        inputs={"data": source},
+        parameters={"instrument": "BERT", "engine": "pygimli"},
+    )
+
+    result = domain.run_ert_single(
+        spec,
+        RunContext(project_root=tmp_path, output_dir=tmp_path / "output"),
+    )
+
+    assert result.status == "success"
+    assert captured["instrument"] is None

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -85,6 +85,26 @@ def test_process_worker_restores_result_from_json(tmp_path: Path) -> None:
     assert received[0].to_dict() == expected.to_dict()
 
 
+def test_process_worker_forwards_structured_progress(tmp_path: Path) -> None:
+    worker = ProcessWorkflowWorker(
+        tmp_path / "recipe.json",
+        tmp_path,
+        tmp_path / "output",
+        tmp_path / "result.json",
+    )
+    progressed = []
+    logged = []
+    worker.progressed.connect(lambda *values: progressed.append(values))
+    worker.logged.connect(logged.append)
+
+    worker._emit_output(
+        b"[progress 2/8] ADTLERT window 2/8 complete, chi2 1.100\n"
+    )
+
+    assert progressed == [(2, 8, "ADTLERT window 2/8 complete, chi2 1.100")]
+    assert logged == ["ADTLERT window 2/8 complete, chi2 1.100"]
+
+
 def test_isolated_ert_cli_does_not_load_unused_pyarrow(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- run all desktop single-survey and time-lapse ERT engines in an isolated `QProcess` so native PyGIMLi/Gauss-Newton work and ADTLERT CUDA work cannot block the Qt event loop
- persist and restore process-safe meshes, models, responses, coverage, convergence history, and time-lapse model arrays for the interactive viewer
- extend the workflow CLI with atomic result-file output and live progress logging, while avoiding the unused pyarrow import that caused a Windows native crash
- force UTF-8 for workflow subprocess streams so Unicode progress messages such as `chi²` cannot fail under a GBK locale
- retain terminate/kill cancellation behavior for isolated workflows

## Validation
- `python -m pytest -q` — 33 passed
- exercised the E4D time-lapsed workflow with both the in-house Gauss-Newton engine and ADTLERT/cuDSS while keeping the Qt window responsive