### PR TITLE
Fix ADTLERT inversion for negative geometric factors

### DIFF
--- a/PyHydroGeophysX/inversion/ert_inversion.py
+++ b/PyHydroGeophysX/inversion/ert_inversion.py
@@ -653,6 +653,55 @@ def _adtlert_survey_supported(container) -> bool:
     )
 
 
+def _canonicalize_adtlert_polarity(container, *, log=_noop_log):
+    """Return an equivalent positive-geometric-factor survey for ADTLERT.
+
+    ADTLERT's fast normal-sensitivity path expects the receiver polarity that
+    gives a positive geometric factor.  A negative factor is physically valid,
+    so canonicalize only the ADTLERT survey copy by exchanging M and N for the
+    affected rows.  Apparent resistivity and errors keep their original order
+    and values; the caller's container is never modified.
+    """
+    n_data = int(container.size())
+    geometric_factors = np.asarray(container["k"], dtype=float).reshape(-1)
+    if geometric_factors.shape != (n_data,):
+        raise ValueError("ADTLERT requires one geometric factor per datum")
+
+    invalid = ~np.isfinite(geometric_factors) | (geometric_factors == 0.0)
+    if np.any(invalid):
+        count = int(np.count_nonzero(invalid))
+        raise ValueError(
+            "ADTLERT requires finite, non-zero geometric factors; "
+            f"found {count} invalid value(s)"
+        )
+
+    negative = geometric_factors < 0.0
+    if not np.any(negative):
+        return container
+
+    normalized = pg.DataContainerERT(container)
+    receiver_m = np.asarray(container["m"], dtype=np.int64).copy()
+    receiver_n = np.asarray(container["n"], dtype=np.int64).copy()
+    normalized_m = receiver_m.copy()
+    normalized_n = receiver_n.copy()
+    normalized_m[negative] = receiver_n[negative]
+    normalized_n[negative] = receiver_m[negative]
+    normalized["m"] = normalized_m
+    normalized["n"] = normalized_n
+
+    normalized_k = geometric_factors.copy()
+    normalized_k[negative] *= -1.0
+    normalized["k"] = normalized_k
+    normalized["r"] = np.asarray(container["rhoa"], dtype=float) / normalized_k
+
+    count = int(np.count_nonzero(negative))
+    log(
+        "  ADTLERT polarity normalization: swapped M/N for "
+        f"{count}/{n_data} negative-k measurements; rhoa and err unchanged"
+    )
+    return normalized
+
+
 def _build_adtlert_forward(container, mesh, *, log=_noop_log):
     """Build one shared ADTLERT forward context for single or windowed ERT."""
     _enable_adtlert_float64()
@@ -690,7 +739,8 @@ def _build_adtlert_forward(container, mesh, *, log=_noop_log):
     result_mesh = mesh.createMeshByCellIdx(pg.IVector(active_ids.tolist()))
     forward_mesh = mesh_to_adtlert(mesh)
     parameter_mesh = mesh_to_adtlert(result_mesh)
-    survey = survey_to_adtlert(container, dimension=2)
+    adtlert_container = _canonicalize_adtlert_polarity(container, log=log)
+    survey = survey_to_adtlert(adtlert_container, dimension=2)
     geometric_mode = (
         "analytic" if bool(forward_mesh.is_flat_surface) else "numerical"
     )

--- a/tests/test_ert_adtlert_backend.py
+++ b/tests/test_ert_adtlert_backend.py
@@ -26,6 +26,7 @@ from PyHydroGeophysX.inversion.ert_inversion import (  # noqa: E402
     _adtlert_cuda_available,
     _adtlert_forward_solver_backend,
     _adtlert_solver_name,
+    _canonicalize_adtlert_polarity,
     run_ert_manager_inversion,
 )
 from PyHydroGeophysX.inversion.windowed import (  # noqa: E402
@@ -36,6 +37,61 @@ from PyHydroGeophysX.inversion.windowed import (  # noqa: E402
 from PyHydroGeophysX.inversion.time_lapse import (  # noqa: E402
     run_timelapse_ert,
 )
+
+
+def _polarity_test_container(k_values=(-10.0, 20.0)):
+    data = ert_inversion.pg.DataContainerERT()
+    for x in range(5):
+        data.createSensor(ert_inversion.pg.Pos(float(x), 0.0))
+    data.resize(2)
+    data["a"] = [0, 0]
+    data["b"] = [3, 4]
+    data["m"] = [1, 1]
+    data["n"] = [2, 2]
+    data["k"] = k_values
+    data["rhoa"] = [100.0, 200.0]
+    data["r"] = [-10.0, 10.0]
+    data["err"] = [0.03, 0.04]
+    return data
+
+
+def test_adtlert_polarity_normalization_is_copy_on_write() -> None:
+    data = _polarity_test_container()
+    original_m = np.asarray(data["m"], dtype=int).copy()
+    original_n = np.asarray(data["n"], dtype=int).copy()
+    messages = []
+
+    normalized = _canonicalize_adtlert_polarity(data, log=messages.append)
+
+    assert normalized is not data
+    np.testing.assert_array_equal(data["m"], original_m)
+    np.testing.assert_array_equal(data["n"], original_n)
+    np.testing.assert_allclose(data["k"], [-10.0, 20.0])
+    np.testing.assert_allclose(data["r"], [-10.0, 10.0])
+    np.testing.assert_array_equal(normalized["m"], [2, 1])
+    np.testing.assert_array_equal(normalized["n"], [1, 2])
+    np.testing.assert_allclose(normalized["k"], [10.0, 20.0])
+    np.testing.assert_allclose(normalized["r"], [10.0, 10.0])
+    np.testing.assert_allclose(normalized["rhoa"], data["rhoa"])
+    np.testing.assert_allclose(normalized["err"], data["err"])
+    assert "1/2 negative-k measurements" in messages[0]
+
+
+def test_adtlert_polarity_normalization_leaves_positive_survey_untouched(
+) -> None:
+    data = _polarity_test_container(k_values=(10.0, 20.0))
+
+    normalized = _canonicalize_adtlert_polarity(data)
+
+    assert normalized is data
+
+
+@pytest.mark.parametrize("invalid_k", [0.0, np.nan, np.inf])
+def test_adtlert_polarity_normalization_rejects_invalid_k(invalid_k) -> None:
+    data = _polarity_test_container(k_values=(invalid_k, 20.0))
+
+    with pytest.raises(ValueError, match="finite, non-zero geometric factors"):
+        _canonicalize_adtlert_polarity(data)
 
 
 def test_adtlert_window_events_are_forwarded_as_readable_progress() -> None:


### PR DESCRIPTION
## Summary

- canonicalize negative geometric-factor polarity at the PyHydroGeophysX-to-ADTLERT adapter boundary
- swap M/N only for affected rows on a copy, then rebuild positive `k` and consistent `r`
- preserve the original container, `rhoa`, errors, observation order, and ADTLERT source code
- add coverage for mixed polarity, already-positive surveys, invalid geometric factors, and copy-on-write behavior

## Root cause

ADTLERT 0.1's fast normal-sensitivity path produced the opposite update direction for surveys represented with negative geometric factors. The data are physically valid, but the resulting Jacobian direction caused a zero first step and prevented the model from updating. Exchanging M/N gives the same physical apparent resistivity in an equivalent positive-geometric-factor representation.

This fix is deliberately limited to survey normalization immediately before `survey_to_adtlert()`. It does not modify Jacobian assembly, forward modelling, inversion iterations, the source data, or other ERT backends.

## Validation

- `tests/test_ert_adtlert_backend.py`: 20 passed
- DD48 field-data regression: all 2,741 negative-`k` rows were normalized
- DD48 chi-squared decreased `739.093 -> 382.560 -> 130.458 -> 33.207 -> 15.147 -> 10.090` and stopped normally at the plateau

The DD48 field data are not included in this pull request.
